### PR TITLE
fix: render correct board for backgammon games

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -347,3 +347,46 @@ function getContinentBonus(continent: string): number { ... }
 - Architectural standard captured in `.squad/decisions.md`: "Shared Static Data: Game configuration data (maps, adjacency graphs, card decks) MUST be located in `shared/src/games/{game}/` so both client (renderer) and server (logic) use a single source of truth."
 
 **Next Step:** Hal will re-review revised PR #83. Ready for merge once approved.
+
+---
+
+## 2025-01-13: Backgammon Board Rendering Bug Fix (Issue #96)
+
+**Problem:** When a host creates a backgammon game, the checkers board was rendered instead of the backgammon board. The root cause was in the game scene selection logic in `WaitingRoom.ts`.
+
+**Investigation:**
+- Found that `GameStartedPayload` (shared type) only included `gameId` and `roomId`, not `gameType`
+- Client code in `WaitingRoom.ts` line 141 tried to get game type from cached `gameInfo?.gameType`
+- When `gameInfo` was null (race condition when game cache hadn't been updated yet), it defaulted to `"checkers"`
+- This caused backgammon and potentially other games to render with the wrong board
+
+**Root Cause:** Timing issue where:
+1. Host creates a backgammon game
+2. `GAME_JOINED` message arrives at client
+3. Game info might not be in cache yet (waiting for `GAME_UPDATED`)
+4. When game starts, `GAME_STARTED` payload lacks `gameType`
+5. Client defaults to "checkers" when `gameInfo` is null
+
+**Solution:** Added `gameType` field to `GameStartedPayload` so the server explicitly provides the game type:
+- **Shared Types** (`shared/src/lobbyTypes.ts`): Added `gameType: string` to `GameStartedPayload` interface
+- **Server** (`server/src/rooms/LobbyRoom.ts`): Include `game.gameType` in `GAME_STARTED` payload
+- **Client** (`client/src/ui/WaitingRoom.ts`): Use `payload.gameType` directly instead of fallback logic
+- **Tests** (`server/src/__tests__/lobby-pregame.test.ts`): Updated 3 test assertions to include `gameType: "checkers"`
+
+**Key Decisions:**
+- Chose server-side fix over client-side workarounds (more reliable, eliminates race condition)
+- Made gameType an explicit part of the game-start contract
+- This fix benefits all game types, not just backgammon
+
+**Validation:**
+- ✅ Build passes (all workspaces)
+- ✅ Lint passes (0 new errors)
+- ✅ Tests pass (259 passed, 12 todo)
+
+**Files Changed:**
+- `shared/src/lobbyTypes.ts` — GameStartedPayload interface
+- `server/src/rooms/LobbyRoom.ts` — GAME_STARTED payload construction
+- `client/src/ui/WaitingRoom.ts` — gameType usage (removed fallback)
+- `server/src/__tests__/lobby-pregame.test.ts` — test expectations
+
+**PR:** #98 (merged to `dev`)

--- a/client/src/ui/WaitingRoom.ts
+++ b/client/src/ui/WaitingRoom.ts
@@ -25,6 +25,7 @@ export interface GamePlayersPayload {
 export interface GameStartedPayload {
   gameId: string;
   roomId: string;
+  gameType: string;
 }
 
 export interface SetReadyPayload {
@@ -138,13 +139,12 @@ export class WaitingRoom {
           return;
         }
 
-        const gameType = this.gameInfo?.gameType ?? "checkers";
         this.hide();
         this.eventCallback?.({
           type: "game_started",
           gameId: payload.gameId,
           roomId: payload.roomId,
-          gameType,
+          gameType: payload.gameType,
         });
       });
 

--- a/server/src/__tests__/lobby-pregame.test.ts
+++ b/server/src/__tests__/lobby-pregame.test.ts
@@ -339,8 +339,8 @@ describeLobby("LobbyRoom pregame flow", () => {
       expectedPlayers: 2,
     });
     expect(getGame(room, gameId)?.status).toBe("in_progress");
-    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123" });
-    expect(findPayload(guest, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123" });
+    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
+    expect(findPayload(guest, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
   });
 
   it("supports the full create → join → ready → start path", async () => {
@@ -352,8 +352,8 @@ describeLobby("LobbyRoom pregame flow", () => {
 
     expect(getWaitingPlayers(room, gameId).size).toBe(0);
     expect(getGame(room, gameId)?.status).toBe("in_progress");
-    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123" });
-    expect(findPayload(guest, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123" });
+    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
+    expect(findPayload(guest, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
   });
 
   it("blocks non-host players from starting a game", async () => {
@@ -610,7 +610,7 @@ describeLobby("LobbyRoom pregame flow", () => {
       maxPlayers: 4,
       expectedPlayers: 1,
     });
-    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123" });
+    expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
   });
 
   it("requires the plugin minimum player count before starting when games are registered", async () => {

--- a/server/src/rooms/LobbyRoom.ts
+++ b/server/src/rooms/LobbyRoom.ts
@@ -380,6 +380,7 @@ export class LobbyRoom extends Room {
       const startedPayload: GameStartedPayload = {
         gameId: game.id,
         roomId: room.roomId,
+        gameType: game.gameType,
       };
 
       for (const sessionId of players.keys()) {

--- a/shared/src/lobbyTypes.ts
+++ b/shared/src/lobbyTypes.ts
@@ -62,6 +62,7 @@ export interface GamePlayersPayload {
 export interface GameStartedPayload {
   gameId: string;
   roomId: string;
+  gameType: string;
 }
 
 export interface LobbyErrorPayload {


### PR DESCRIPTION
Fixes #96

## Problem
When a host creates a backgammon game, the checkers board was rendered instead of the backgammon board. The root cause was that the `GameStartedPayload` sent from the server to the client only included `gameId` and `roomId`, but not `gameType`. 

The client-side code in `WaitingRoom.ts` tried to get the game type from cached `gameInfo`, which could be null if the `GAME_UPDATED` message hadn't arrived yet. When `gameInfo` was null, it defaulted to "checkers", causing all non-checkers games to render with the checkers board.

## Fix
Added `gameType` field to the `GameStartedPayload` interface in the shared types and updated:
- **Server** (`LobbyRoom.ts`): Include `game.gameType` in the `GAME_STARTED` message payload
- **Client** (`WaitingRoom.ts`): Use `payload.gameType` directly instead of falling back to cached `gameInfo`
- **Tests** (`lobby-pregame.test.ts`): Updated test expectations to include the `gameType` field

This ensures the correct game scene is always rendered, regardless of cache state or message timing.