### PR TITLE
feat: add lobby event message log

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -643,6 +643,97 @@
         font-size: 0.875rem;
       }
 
+      /* Message Log Panel */
+      .message-log-panel {
+        border-radius: 12px;
+        background: rgba(39, 39, 42, 0.5);
+        backdrop-filter: blur(12px);
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        max-height: 400px;
+      }
+
+      .message-log-content {
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-width: thin;
+        scrollbar-color: #3f3f46 transparent;
+      }
+
+      .message-log-content::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      .message-log-content::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      .message-log-content::-webkit-scrollbar-thumb {
+        background: #3f3f46;
+        border-radius: 3px;
+      }
+
+      .message-log-content::-webkit-scrollbar-thumb:hover {
+        background: #52525b;
+      }
+
+      .message-log-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .message-log-entry {
+        padding: 0.5rem;
+        border-radius: 6px;
+        background: rgba(24, 24, 27, 0.5);
+        font-size: 0.875rem;
+        line-height: 1.4;
+        display: flex;
+        gap: 0.5rem;
+        align-items: flex-start;
+        border-left: 2px solid transparent;
+      }
+
+      .message-log-entry--player_joined {
+        border-left-color: #22c55e;
+      }
+
+      .message-log-entry--player_left {
+        border-left-color: #71717a;
+      }
+
+      .message-log-entry--game_created {
+        border-left-color: #7c3aed;
+      }
+
+      .message-log-entry--game_started {
+        border-left-color: #f59e0b;
+      }
+
+      .message-log-entry--game_finished {
+        border-left-color: #3b82f6;
+      }
+
+      .message-log-entry--player_joined_game {
+        border-left-color: #a855f7;
+      }
+
+      .message-log-time {
+        color: #71717a;
+        font-size: 0.75rem;
+        font-weight: 500;
+        flex-shrink: 0;
+        line-height: 1.4;
+      }
+
+      .message-log-text {
+        color: #d4d4d8;
+        flex: 1;
+      }
+
       /* Create Game Modal */
       .create-game-modal {
         position: fixed;

--- a/client/src/ui/LobbyScreen.ts
+++ b/client/src/ui/LobbyScreen.ts
@@ -1,4 +1,5 @@
 import type { Room } from "@colyseus/sdk";
+import { MessageLog } from "./MessageLog.js";
 
 export const CREATE_GAME = "create_game" as const;
 export const JOIN_GAME = "join_game" as const;
@@ -13,6 +14,7 @@ export const GAME_STARTED = "game_started" as const;
 export const GAME_PLAYERS = "game_players" as const;
 export const LOBBY_ERROR = "lobby_error" as const;
 export const ONLINE_PLAYERS = "online_players" as const;
+export const LOBBY_LOG_EVENT = "lobby_log_event" as const;
 
 export type GameStatus = "waiting" | "in_progress" | "ended";
 
@@ -84,6 +86,24 @@ export type LobbyEvent =
 type LobbyFilter = "all" | "waiting" | "in_progress";
 type NoticeTone = "info" | "error";
 type LobbyEventCallback = (event: LobbyEvent) => void;
+
+export type LobbyLogEventType =
+  | "player_joined"
+  | "player_left"
+  | "game_created"
+  | "game_started"
+  | "game_finished"
+  | "player_joined_game";
+
+export interface LobbyLogEntry {
+  timestamp: number;
+  type: LobbyLogEventType;
+  message: string;
+  playerName?: string;
+  gameName?: string;
+  gameType?: string;
+  winner?: string;
+}
 
 interface GameTypeOption {
   value: string;
@@ -284,6 +304,7 @@ export class LobbyScreen {
   private readonly onlinePlayers: OnlinePlayerInfo[] = [];
   private readonly onlinePlayersListEl: HTMLElement;
   private readonly onlinePlayersBadgeEl: HTMLElement;
+  private messageLog: MessageLog | null = null;
 
   private room: Room | null = null;
   private boundRoom: Room | null = null;
@@ -414,7 +435,16 @@ export class LobbyScreen {
     this.onlinePlayersListEl.append(createElement("div", "panel-empty", "No players online"));
     onlinePlayersPanel.append(onlinePlayersHeader, this.onlinePlayersListEl);
     
-    sidebar.append(activeGamesPanel, onlinePlayersPanel);
+    // Message Log Panel
+    const messageLogPanel = createElement("div", "message-log-panel");
+    const messageLogHeader = createElement("div", "panel-header");
+    const messageLogTitle = createElement("h2", "panel-title", "Activity Feed");
+    messageLogHeader.append(messageLogTitle);
+    const messageLogContent = createElement("div", "message-log-content");
+    messageLogPanel.append(messageLogHeader, messageLogContent);
+    this.messageLog = new MessageLog(messageLogContent);
+    
+    sidebar.append(activeGamesPanel, onlinePlayersPanel, messageLogPanel);
 
     grid.append(gameLibrary, sidebar);
     content.append(grid);
@@ -592,6 +622,10 @@ export class LobbyScreen {
       this.onlinePlayers.length = 0;
       this.onlinePlayers.push(...payload.players);
       this.renderOnlinePlayers();
+    });
+
+    room.onMessage(LOBBY_LOG_EVENT, (entry: LobbyLogEntry) => {
+      this.messageLog?.addMessage(entry);
     });
   }
 

--- a/client/src/ui/MessageLog.ts
+++ b/client/src/ui/MessageLog.ts
@@ -1,0 +1,79 @@
+import type { LobbyLogEntry } from "@eschaton/shared";
+
+export class MessageLog {
+  private container: HTMLElement;
+  private logList: HTMLElement;
+  private maxMessages = 50;
+  private messages: LobbyLogEntry[] = [];
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+    this.logList = this.createLogList();
+    this.container.appendChild(this.logList);
+  }
+
+  private createLogList(): HTMLElement {
+    const list = document.createElement("div");
+    list.className = "message-log-list";
+    return list;
+  }
+
+  addMessage(entry: LobbyLogEntry): void {
+    this.messages.push(entry);
+
+    if (this.messages.length > this.maxMessages) {
+      this.messages.shift();
+    }
+
+    this.render();
+    this.scrollToBottom();
+  }
+
+  clear(): void {
+    this.messages = [];
+    this.render();
+  }
+
+  private render(): void {
+    this.logList.innerHTML = "";
+
+    for (const message of this.messages) {
+      const messageElement = this.createMessageElement(message);
+      this.logList.appendChild(messageElement);
+    }
+  }
+
+  private createMessageElement(entry: LobbyLogEntry): HTMLElement {
+    const element = document.createElement("div");
+    element.className = `message-log-entry message-log-entry--${entry.type}`;
+
+    const timestamp = this.formatTimestamp(entry.timestamp);
+    const timeElement = document.createElement("span");
+    timeElement.className = "message-log-time";
+    timeElement.textContent = timestamp;
+
+    const messageElement = document.createElement("span");
+    messageElement.className = "message-log-text";
+    messageElement.textContent = entry.message;
+
+    element.appendChild(timeElement);
+    element.appendChild(messageElement);
+
+    return element;
+  }
+
+  private formatTimestamp(timestamp: number): string {
+    const date = new Date(timestamp);
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    return `${hours}:${minutes}`;
+  }
+
+  private scrollToBottom(): void {
+    this.container.scrollTop = this.container.scrollHeight;
+  }
+
+  destroy(): void {
+    this.container.innerHTML = "";
+  }
+}

--- a/server/src/__tests__/lobby-pregame.test.ts
+++ b/server/src/__tests__/lobby-pregame.test.ts
@@ -25,6 +25,7 @@ const { mockCreateRoom, mockGameRegistry, mockedCloseCode, sharedExports } = vi.
     GAME_PLAYERS: "game_players",
     LOBBY_ERROR: "lobby_error",
     ONLINE_PLAYERS: "online_players",
+    LOBBY_LOG_EVENT: "lobby_log_event",
     DEFAULT_MAP_SIZE: 128,
     LOBBY_DEFAULTS: {
       MIN_PLAYERS: 1,

--- a/server/src/rooms/LobbyRoom.ts
+++ b/server/src/rooms/LobbyRoom.ts
@@ -10,6 +10,7 @@ import {
   JOIN_GAME,
   LEAVE_GAME,
   LOBBY_ERROR,
+  LOBBY_LOG_EVENT,
   ONLINE_PLAYERS,
   SET_READY,
   START_GAME,
@@ -20,6 +21,7 @@ import {
   type GameStartedPayload,
   type JoinGamePayload,
   type LobbyErrorPayload,
+  type LobbyLogEntry,
   type OnlinePlayerInfo,
   type OnlinePlayersPayload,
   type PreGamePlayerInfo,
@@ -67,6 +69,12 @@ export class LobbyRoom extends Room {
     this.games.delete(message.gameId);
     this.broadcast(GAME_REMOVED, { gameId: message.gameId });
     this.broadcastOnlinePlayers();
+    this.broadcastLobbyEvent({
+      type: "game_finished",
+      message: `🏁 ${game.name} finished`,
+      gameName: game.name,
+      gameType: game.gameType,
+    });
 
     console.log(`[LobbyRoom] Removed disposed game ${message.gameId} from the lobby`);
   };
@@ -121,6 +129,11 @@ export class LobbyRoom extends Room {
     });
 
     this.broadcastOnlinePlayers();
+    this.broadcastLobbyEvent({
+      type: "player_joined",
+      message: `👋 ${displayName} joined the lobby`,
+      playerName: displayName,
+    });
 
     console.log(`[LobbyRoom] ${displayName} joined the lobby`);
   }
@@ -197,6 +210,13 @@ export class LobbyRoom extends Room {
     client.send(GAME_JOINED, payloadOut);
     this.broadcast(GAME_UPDATED, { game: this.toGameSessionInfo(game) });
     this.broadcastGamePlayers(gameId);
+    this.broadcastLobbyEvent({
+      type: "game_created",
+      message: `🎮 ${session.displayName} created a ${gameType} game`,
+      playerName: session.displayName,
+      gameName: name,
+      gameType,
+    });
 
     console.log(`[LobbyRoom] Created game ${gameId} (${name}, ${gameType})`);
   }
@@ -272,6 +292,13 @@ export class LobbyRoom extends Room {
     client.send(GAME_JOINED, joinedPayload);
     this.broadcast(GAME_UPDATED, { game: this.toGameSessionInfo(game) });
     this.broadcastGamePlayers(game.id);
+    this.broadcastLobbyEvent({
+      type: "player_joined_game",
+      message: `🎲 ${session.displayName} joined ${game.name}`,
+      playerName: session.displayName,
+      gameName: game.name,
+      gameType: game.gameType,
+    });
 
     console.log(`[LobbyRoom] ${session.displayName} joined game ${game.id}`);
   }
@@ -388,6 +415,13 @@ export class LobbyRoom extends Room {
         playerClient?.send(GAME_STARTED, startedPayload);
       }
 
+      this.broadcastLobbyEvent({
+        type: "game_started",
+        message: `🚀 ${game.name} started`,
+        gameName: game.name,
+        gameType: game.gameType,
+      });
+
       this.waitingPlayers.delete(game.id);
       console.log(`[LobbyRoom] Started game ${game.id} in room ${room.roomId}`);
     } catch (error) {
@@ -474,6 +508,11 @@ export class LobbyRoom extends Room {
     this.handleLeaveGame(sessionId);
     this.sessions.delete(sessionId);
     this.broadcastOnlinePlayers();
+    this.broadcastLobbyEvent({
+      type: "player_left",
+      message: `👋 ${session.displayName} left the lobby`,
+      playerName: session.displayName,
+    });
   }
 
   private resolveSessionId(clientOrSessionId: Client | string) {
@@ -518,6 +557,14 @@ export class LobbyRoom extends Room {
   private sendError(client: Client, message: string) {
     const payload: LobbyErrorPayload = { message };
     client.send(LOBBY_ERROR, payload);
+  }
+
+  private broadcastLobbyEvent(entry: Omit<LobbyLogEntry, "timestamp">) {
+    const event: LobbyLogEntry = {
+      ...entry,
+      timestamp: Date.now(),
+    };
+    this.broadcast(LOBBY_LOG_EVENT, event);
   }
 
   private normalizeGameName(value: unknown) {

--- a/shared/src/lobbyTypes.ts
+++ b/shared/src/lobbyTypes.ts
@@ -12,6 +12,7 @@ export const GAME_STARTED = "game_started" as const;
 export const GAME_PLAYERS = "game_players" as const;
 export const LOBBY_ERROR = "lobby_error" as const;
 export const ONLINE_PLAYERS = "online_players" as const;
+export const LOBBY_LOG_EVENT = "lobby_log_event" as const;
 
 export type GameStatus = "waiting" | "in_progress";
 
@@ -77,4 +78,22 @@ export interface OnlinePlayerInfo {
 
 export interface OnlinePlayersPayload {
   players: OnlinePlayerInfo[];
+}
+
+export type LobbyLogEventType =
+  | "player_joined"
+  | "player_left"
+  | "game_created"
+  | "game_started"
+  | "game_finished"
+  | "player_joined_game";
+
+export interface LobbyLogEntry {
+  timestamp: number;
+  type: LobbyLogEventType;
+  message: string;
+  playerName?: string;
+  gameName?: string;
+  gameType?: string;
+  winner?: string;
 }


### PR DESCRIPTION
## Overview
Adds a real-time activity feed to the lobby UI showing various lobby events.

## What's Changed

### Server Side (LobbyRoom)
- Added `LOBBY_LOG_EVENT` message type for broadcasting lobby events
- Created `broadcastLobbyEvent()` helper method to broadcast events with timestamps
- Integrated event broadcasting into:
  - Player join/leave events (👋 greetings)
  - Game creation (🎮 with game type and host name)
  - Game start (🚀 with game name)
  - Game finish (🏁 when game room disposes)
  - Players joining games (🎲 with player and game names)

### Shared Types
- Added `LOBBY_LOG_EVENT` constant
- Added `LobbyLogEventType` union type (player_joined, player_left, game_created, game_started, game_finished, player_joined_game)
- Added `LobbyLogEntry` interface with timestamp, type, message, and optional metadata

### Client Side (LobbyScreen)
- Created new `MessageLog` component for displaying scrollable event feed
- Added message log panel to lobby sidebar
- Configured auto-scroll to bottom on new messages
- Implemented 50-message limit to prevent memory issues
- Added message handler for `LOBBY_LOG_EVENT`

### UI/UX
- Added "Activity Feed" panel in lobby sidebar
- Clean, color-coded messages with emoji indicators
- Timestamps in HH:MM format
- Scrollable with custom scrollbar styling
- Border colors by event type:
  - 🟢 Player joined (green)
  - ⚪ Player left (gray)
  - 🟣 Game created (purple)
  - 🟡 Game started (orange)
  - 🔵 Game finished (blue)
  - 🟪 Player joined game (light purple)

## Testing
- ✅ Build passes
- ✅ Lint passes (no new warnings)
- ✅ All tests pass (259 tests)
- Updated test mock to include new `LOBBY_LOG_EVENT` constant

## Screenshots
The activity feed appears in the lobby sidebar below the Online Players panel, showing real-time events as they occur.

Closes #[issue-number-if-applicable]