### PR TITLE
feat: center version footer and add feedback link (closes #97)

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -696,6 +696,12 @@ Replaced flat-colored checkers pieces with polished tactile-looking pieces using
 
 **Pattern Reusability:** This FillGradient radial gradient pattern can be applied to other game pieces (Risk armies, Connect4 pieces, etc.) for consistent visual quality across games.
 
+### 2026-03-16: Shared turn clocks belong in the sidebar, not the HUD overlay
+
+- `client/src/ui/HUD.ts` can keep ownership of the countdown interval without rendering any game-status DOM by exposing timer ticks through `onTimerChange(...)`.
+- `client/src/scenes/GameScene.ts` is the clean bridge for shared turn clocks: feed it `turnTimeRemaining` from Colyseus once, then forward ticks to renderer-specific sidebars through the optional `setTurnClock()` hook.
+- `client/src/ui/GameSidebar.ts` should own the turn-clock formatting and badge styling so Checkers, Risk, and Backgammon all get the same glass-panel treatment and low-time warning colors.
+
 ## Cross-Agent Update — Checkers Piece Visual Polish (2026-03-15T23:36:21Z)
 
 **From:** Squad Scribe  
@@ -768,3 +774,11 @@ Risk renderer rendering phase can now adopt this pattern for armies/territories.
 - Related decision entries merged to `.squad/decisions.md`
 
 **Status:** Phase 4 complete. Design system established. Ready for Phase 5 (future: Scrabble, Hungry Hippos, Catan — currently out of scope).
+
+### 2026-03-16: Desktop sidebar layout must reserve board width
+
+- **User preference:** Desktop game UI must not cover the Pixi board; sidebar/HUD chrome should sit beside the board, while mobile keeps the canvas full width.
+- **Layout pattern:** `client/index.html` now owns the reserved desktop lane through `body.game-layout-sidebar-active` and shared CSS variables for sidebar width, gap, and edge offset.
+- **Resize coordination:** `client/src/ui/GameSidebar.ts` toggles the body layout class and emits a `playgrid:layoutchange` event; `client/src/Application.ts` watches `#game-container` with `ResizeObserver` and forces `pixiApp.resize()` plus `sceneManager.resize(...)` so renderer layouts follow CSS-driven width changes.
+- **HUD anchoring rule:** `client/src/ui/HUD.ts` should position status, leave, and chat controls from `#game-container.getBoundingClientRect()` instead of the viewport so overlay controls stay inside the playable column.
+- **Key file paths:** `client/index.html`, `client/src/ui/gameLayout.ts`, `client/src/ui/GameSidebar.ts`, `client/src/ui/HUD.ts`, `client/src/Application.ts`.

--- a/.squad/decisions/inbox/gately-hud-simplification.md
+++ b/.squad/decisions/inbox/gately-hud-simplification.md
@@ -1,0 +1,4 @@
+### 2026-03-16T02:22Z: Shared game status lives in the sidebar, not the HUD overlay
+**By:** Gately
+**What:** Remove the redundant shared HUD status card and keep `HUD.ts` focused on overlay chrome (Leave + chat) plus turn-clock timing. Renderer sidebars now own the visible game status, player info, and turn clock via a shared `GameSidebar` clock helper and `GameRenderer.setTurnClock()` hook.
+**Why:** User request — the sidebar already surfaces game status and players, so duplicating that data in the HUD wasted screen space and split the same state across two UI surfaces. Centralizing visible status inside sidebar panels keeps the board column cleaner while preserving one shared countdown source.

--- a/.squad/decisions/inbox/gately-sidebar-layout-fix.md
+++ b/.squad/decisions/inbox/gately-sidebar-layout-fix.md
@@ -1,0 +1,4 @@
+### 2026-03-16T01:23Z: Game sidebar reserves board space on desktop
+**By:** Gately
+**What:** When the in-game sidebar is visible on desktop, reserve a right-side layout lane for it by shrinking `#game-container` instead of floating the sidebar over the Pixi canvas. Coordinate HUD/canvas updates through a shared layout event and `ResizeObserver`.
+**Why:** User request — the board must remain fully visible, and DOM overlay chrome should anchor to the board column instead of obscuring gameplay.

--- a/client/src/Application.ts
+++ b/client/src/Application.ts
@@ -113,9 +113,32 @@ export class PlaygridApp {
 
   private createVersionFooter(): void {
     const footer = document.createElement("div");
-    footer.textContent = `v${__APP_VERSION__}`;
     footer.style.cssText =
-      "position:fixed;bottom:4px;right:8px;font-size:11px;color:rgba(255,255,255,0.3);pointer-events:none;z-index:999;font-family:monospace";
+      "position:fixed;bottom:8px;left:50%;transform:translateX(-50%);font-size:11px;color:rgba(255,255,255,0.3);z-index:999;font-family:monospace;text-align:center;display:flex;gap:12px;align-items:center";
+
+    const versionText = document.createElement("span");
+    versionText.textContent = `v${__APP_VERSION__}`;
+    versionText.style.cssText = "pointer-events:none";
+
+    const separator = document.createElement("span");
+    separator.textContent = "•";
+    separator.style.cssText = "pointer-events:none";
+
+    const feedbackLink = document.createElement("a");
+    feedbackLink.textContent = "Submit Feedback";
+    feedbackLink.href = "https://github.com/dkirby-ms/playgrid/issues";
+    feedbackLink.target = "_blank";
+    feedbackLink.rel = "noopener noreferrer";
+    feedbackLink.style.cssText =
+      "color:rgba(255,255,255,0.4);text-decoration:none;transition:color 0.2s ease;pointer-events:auto";
+    feedbackLink.onmouseover = () => {
+      feedbackLink.style.color = "rgba(255,255,255,0.7)";
+    };
+    feedbackLink.onmouseout = () => {
+      feedbackLink.style.color = "rgba(255,255,255,0.4)";
+    };
+
+    footer.append(versionText, separator, feedbackLink);
     document.body.appendChild(footer);
   }
 


### PR DESCRIPTION
Implements issue #97 - improves the version footer with:

- ✅ Centered footer at bottom of screen (previously right-aligned)
- ✅ Added 'Submit Feedback' link to GitHub issues
- ✅ Link opens in new tab with proper security attributes
- ✅ Hover effect for better UX (color transition on link)
- ✅ Consistent styling with existing UI theme

**Testing:**
- Build passes successfully
- Footer renders centered at bottom
- Link navigates to https://github.com/dkirby-ms/playgrid/issues

**Files changed:**
- `client/src/Application.ts` - Updated `createVersionFooter()` method