### PR TITLE
feat: UX redesign — lobby + Dominos renderer (Figma spec)

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -1031,3 +1031,12 @@ Risk renderer rendering phase can now adopt this pattern for armies/territories.
 - **Exported test helpers**: `getPlayerHand`, `setPlayerHand`, `getPlayerHands` exported from DominosPlugin.ts for test setup.
 - **Key insight**: Colyseus schema auto-syncs everything to all clients. The ONLY way to keep data hidden is to NOT put it in the schema. Module-scoped Maps keyed by state instance work well for this.
 - **Validation:** `npm run build && npm run lint && npm run test` — all green (0 errors, 382 tests pass, 12 todo).
+
+### 2026-03-17: UX Redesign — Lobby + Dominos Renderer (Figma → Live)
+
+- **Design pipeline:** Figma exports land in `docs/designs/playgrid-ux/` as React/shadcn components. We convert them to the live PixiJS + HTML DOM implementation.
+- **Lobby changes:** Migrated color palette from zinc/violet to slate/blue. Background gradient `from-slate-950 via-slate-900 to-slate-800`. Header, filter buttons, game tiles, sidebar panels, active game cards, online players all updated. Added Dominos to `GAME_TYPE_OPTIONS` (2-4 players) and `GAME_TILE_ARTWORK`.
+- **DominosRenderer:** Added emerald green board background (EMERALD_800/900 tokens). New "How to Play" sidebar panel with gameplay instructions. Renamed "Game Info" to "Game Status". Empty board text now shows "Play any domino to start" in emerald-tinted color.
+- **DesignTokens:** Added `EMERALD_800` (0x065F46) and `EMERALD_900` (0x064E3B) for the dominos board surface.
+- **Preserved:** All Colyseus room bindings, message handlers, game creation/joining flow, filter logic, online player rendering unchanged.
+- **Validation:** `npm run build && npm run lint && npm run test` — all green.

--- a/.squad/decisions/inbox/gately-ux-redesign.md
+++ b/.squad/decisions/inbox/gately-ux-redesign.md
@@ -1,0 +1,31 @@
+### Gately: UX Redesign — Lobby + Dominos Renderer (Figma Match)
+
+**Status:** Proposed  
+**Date:** 2026-03-17  
+**Branch:** `squad/ux-redesign-lobby-dominos`
+
+Migrate lobby and Dominos renderer visual styling to match the new Figma export at `docs/designs/playgrid-ux/`. Lobby shifts from zinc/violet palette to dark slate/blue; Dominos gains an emerald green board surface and new sidebar panels.
+
+**Rationale:**
+- Design-first workflow: Figma → React export → convert to live implementation
+- Dark slate palette (slate-950/900/800) feels more polished than the prior zinc-only background
+- Blue accents for game tiles, buttons, and avatars align with the Figma design language
+- Emerald board surface for Dominos makes the playing area visually distinct from the dark chrome
+- "How to Play" sidebar panel improves onboarding for new players
+
+**Implementation:**
+- `client/index.html`: CSS color values migrated from zinc/violet to slate/blue across lobby dashboard, header, game tiles, sidebar panels, active game cards, online players, filter buttons
+- `client/src/ui/LobbyScreen.ts`: Added Dominos to `GAME_TYPE_OPTIONS` (2-4 players) and `GAME_TILE_ARTWORK`
+- `client/src/renderers/DominosRenderer.ts`: Added emerald board background, "How to Play" sidebar panel, renamed "Game Info" → "Game Status", updated empty board text
+- `client/src/renderers/DesignTokens.ts`: Added `EMERALD_800`, `EMERALD_900` tokens
+
+**Impact:**
+- Visual-only changes: No game logic, state management, or networking modified
+- All existing Colyseus integration (room listing, creation, joining, player sync) preserved
+- Dominos now appears in the lobby game type selector
+
+**Files Modified:**
+- client/index.html
+- client/src/ui/LobbyScreen.ts
+- client/src/renderers/DominosRenderer.ts
+- client/src/renderers/DesignTokens.ts

--- a/client/index.html
+++ b/client/index.html
@@ -158,7 +158,7 @@
         display: none;
         z-index: 10;
         overflow-y: auto;
-        background: linear-gradient(to bottom right, #18181b, #18181b, #3b0764);
+        background: linear-gradient(to bottom right, #020617, #0f172a, #1e293b);
       }
 
       #lobby-overlay.visible {
@@ -169,13 +169,13 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
-        background: var(--gradient-page);
+        background: linear-gradient(to bottom right, #020617, #0f172a, #1e293b);
       }
 
       /* Header */
       .lobby-header {
-        border-bottom: 1px solid var(--border-default);
-        background: var(--bg-dark);
+        border-bottom: 1px solid #1e293b;
+        background: rgba(15, 23, 42, 0.5);
         backdrop-filter: blur(var(--glass-blur));
         -webkit-backdrop-filter: blur(var(--glass-blur));
         position: sticky;
@@ -208,7 +208,7 @@
         width: 40px;
         height: 40px;
         border-radius: 8px;
-        background: linear-gradient(to bottom right, #7c3aed, #9333ea);
+        background: linear-gradient(to bottom right, #2563eb, #1d4ed8);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -247,8 +247,8 @@
       .lobby-header-button {
         padding: 0.5rem;
         border-radius: 8px;
-        background: #27272a;
-        color: #a1a1aa;
+        background: #1e293b;
+        color: #94a3b8;
         border: none;
         cursor: pointer;
         transition: all 0.2s;
@@ -258,7 +258,7 @@
       }
 
       .lobby-header-button:hover {
-        background: #3f3f46;
+        background: #334155;
         color: white;
       }
 
@@ -273,15 +273,15 @@
         gap: 0.5rem;
         padding: 0.5rem 1rem;
         border-radius: 8px;
-        background: #27272a;
-        color: #a1a1aa;
+        background: #1e293b;
+        color: #94a3b8;
         border: none;
         cursor: pointer;
         transition: all 0.2s;
       }
 
       .lobby-header-user:hover {
-        background: #3f3f46;
+        background: #334155;
         color: white;
       }
 
@@ -379,10 +379,10 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.5rem 0.875rem;
-        border: 1px solid #3f3f46;
+        border: 1px solid #334155;
         border-radius: 999px;
         background: transparent;
-        color: #d4d4d8;
+        color: #cbd5e1;
         font: inherit;
         font-size: 0.875rem;
         cursor: pointer;
@@ -390,13 +390,13 @@
       }
 
       .lobby-filter-button:hover {
-        background: rgba(124, 58, 237, 0.1);
-        border-color: #7c3aed;
+        background: rgba(59, 130, 246, 0.1);
+        border-color: #3b82f6;
       }
 
       .lobby-filter-button.active {
-        background: rgba(124, 58, 237, 0.2);
-        border-color: #7c3aed;
+        background: rgba(59, 130, 246, 0.2);
+        border-color: #3b82f6;
         color: white;
       }
 
@@ -437,7 +437,7 @@
         position: relative;
         overflow: hidden;
         border-radius: var(--glass-radius);
-        background: var(--glass-bg);
+        background: #1e293b;
         backdrop-filter: blur(var(--glass-blur));
         -webkit-backdrop-filter: blur(var(--glass-blur));
         border: 1px solid var(--border-light);
@@ -448,9 +448,10 @@
       }
 
       .game-tile:hover {
-        transform: scale(1.02);
-        border-color: var(--accent-violet);
-        background: rgba(124, 58, 237, 0.1);
+        transform: scale(1.05);
+        box-shadow: 0 20px 40px rgba(59, 130, 246, 0.2);
+        border-color: rgba(59, 130, 246, 0.5);
+        background: #1e293b;
         backdrop-filter: blur(var(--glass-blur));
         -webkit-backdrop-filter: blur(var(--glass-blur));
       }
@@ -518,7 +519,7 @@
       }
 
       .game-tile-active {
-        color: var(--accent-violet);
+        color: #60a5fa;
         font-weight: 500;
       }
 
@@ -533,10 +534,10 @@
       .active-games-panel,
       .online-players-panel {
         border-radius: var(--glass-radius);
-        background: var(--glass-bg);
+        background: rgba(30, 41, 59, 0.5);
         backdrop-filter: blur(var(--glass-blur));
         -webkit-backdrop-filter: blur(var(--glass-blur));
-        border: 1px solid var(--glass-border);
+        border: 1px solid rgba(51, 65, 85, 0.5);
         padding: var(--space-lg);
       }
 
@@ -556,7 +557,7 @@
       .panel-badge {
         padding: 0.25rem 0.625rem;
         border-radius: 999px;
-        background: var(--accent-violet-bg);
+        background: #2563eb;
         color: white;
         font-size: 0.875rem;
         font-weight: 600;
@@ -581,14 +582,14 @@
       /* Active Game Card */
       .active-game-card {
         border-radius: 0.5rem;
-        background: var(--bg-card-dark);
+        background: rgba(15, 23, 42, 0.5);
         padding: 0.75rem;
-        border: 1px solid var(--glass-border);
+        border: 1px solid rgba(51, 65, 85, 0.5);
         transition: all 0.2s;
       }
 
       .active-game-card:hover {
-        border-color: var(--accent-violet);
+        border-color: rgba(59, 130, 246, 0.5);
       }
 
       .active-game-info {
@@ -659,8 +660,8 @@
         width: 24px;
         height: 24px;
         border-radius: 999px;
-        background: linear-gradient(to bottom right, #7c3aed, #9333ea);
-        border: 2px solid #18181b;
+        background: linear-gradient(to bottom right, #3b82f6, #2563eb);
+        border: 2px solid #0f172a;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -675,7 +676,7 @@
         gap: 0.25rem;
         padding: 0.25rem 0.75rem;
         border-radius: 6px;
-        background: #7c3aed;
+        background: #2563eb;
         color: white;
         border: none;
         cursor: pointer;
@@ -685,7 +686,7 @@
       }
 
       .active-game-join-btn:hover {
-        background: #6d28d9;
+        background: #1d4ed8;
       }
 
       .active-game-join-btn svg {
@@ -700,13 +701,13 @@
         gap: 0.75rem;
         padding: 0.5rem;
         border-radius: 0.5rem;
-        background: var(--bg-card-dark);
-        border: 1px solid var(--glass-border);
+        background: rgba(15, 23, 42, 0.5);
+        border: 1px solid rgba(51, 65, 85, 0.5);
         transition: all 0.2s;
       }
 
       .online-player-item:hover {
-        background: var(--bg-dark);
+        background: #0f172a;
       }
 
       .online-player-avatar-wrapper {
@@ -718,7 +719,7 @@
         width: 40px;
         height: 40px;
         border-radius: 999px;
-        background: var(--gradient-button-primary);
+        background: linear-gradient(to bottom right, #3b82f6, #2563eb);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -733,7 +734,7 @@
         width: 12px;
         height: 12px;
         border-radius: 999px;
-        border: 2px solid var(--bg-glass);
+        border: 2px solid #1e293b;
       }
 
       .online-player-status-dot.online {
@@ -771,10 +772,10 @@
       /* Message Log Panel */
       .message-log-panel {
         border-radius: var(--glass-radius);
-        background: var(--glass-bg);
+        background: rgba(30, 41, 59, 0.5);
         backdrop-filter: blur(var(--glass-blur));
         -webkit-backdrop-filter: blur(var(--glass-blur));
-        border: 1px solid var(--border-light);
+        border: 1px solid rgba(51, 65, 85, 0.5);
         padding: 1rem;
         display: flex;
         flex-direction: column;

--- a/client/src/renderers/DesignTokens.ts
+++ b/client/src/renderers/DesignTokens.ts
@@ -110,6 +110,11 @@ export const ZINC_800 = 0x18181B;
 export const ZINC_900 = 0x0A0A0A;
 export const ZINC_950 = 0x09090B;
 
+// === Emerald (Dominos board) ===
+export const EMERALD_800 = 0x065F46;
+export const EMERALD_900 = 0x064E3B;
+
+// === Slate (Dark theme palette) ===
 export const SLATE_100 = 0xF1F5F9;
 export const SLATE_300 = 0xCBD5E1;
 export const SLATE_400 = 0x94A3B8;

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -14,8 +14,9 @@ import {
   BLACK as TOKEN_BLACK,
   BORDER_LIGHT,
   BORDER_LIGHT_ALPHA,
+  EMERALD_800,
+  EMERALD_900,
   STATUS_ONLINE,
-  TEXT_MUTED,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_SUBTLE,
@@ -126,6 +127,7 @@ export class DominosRenderer implements GameRenderer {
   readonly container = new Container();
 
   // ── Layers ──────────────────────────────────────────────────────────────
+  private readonly boardBackground = new Graphics();
   private readonly boardLayer = new Container();
   private readonly handLayer = new Container();
   private readonly overlayLayer = new Container();
@@ -221,6 +223,7 @@ export class DominosRenderer implements GameRenderer {
     this.boneyardCountText.anchor.set(0.5);
 
     this.container.addChild(
+      this.boardBackground,
       this.boardLayer,
       this.endMarkerA,
       this.endMarkerB,
@@ -248,8 +251,9 @@ export class DominosRenderer implements GameRenderer {
 
     this.sidebar?.destroy();
     this.sidebar = new GameSidebar();
-    this.sidebar.addPanel("game-info", "Game Info");
+    this.sidebar.addPanel("game-info", "Game Status");
     this.sidebar.addPanel("players", "Players");
+    this.sidebar.addPanel("how-to-play", "How to Play");
     this.sidebar.addPanel("controls", "Controls");
     this.sidebar.show();
 
@@ -502,12 +506,35 @@ export class DominosRenderer implements GameRenderer {
   // ═══════════════════════════════════════════════════════════════════════════
 
   private redrawAll(): void {
+    this.redrawBoardBackground();
     this.redrawBoard();
     this.redrawHand();
     this.redrawBoneyard();
     this.redrawEndMarkers();
     this.updateOverlay();
     this.updateSidebar();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Board background (emerald green playing surface)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private redrawBoardBackground(): void {
+    this.boardBackground.clear();
+    const padding = VIEW_PADDING;
+    const x = padding;
+    const y = TOP_HUD_SPACE;
+    const w = this.width - padding * 2;
+    const h = this.height - TOP_HUD_SPACE - BOTTOM_HUD_SPACE;
+
+    this.boardBackground
+      .roundRect(x, y, w, h, 10)
+      .fill(EMERALD_900);
+
+    // Subtle lighter emerald inner area
+    this.boardBackground
+      .roundRect(x + 4, y + 4, w - 8, h - 8, 8)
+      .fill(EMERALD_800);
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -519,8 +546,8 @@ export class DominosRenderer implements GameRenderer {
 
     if (this.boardTiles.length === 0) {
       const emptyText = new Text({
-        text: "No tiles played yet",
-        style: { fontFamily: "sans-serif", fontSize: 16, fill: TEXT_MUTED },
+        text: "Play any domino to start",
+        style: { fontFamily: "sans-serif", fontSize: 16, fill: 0xa7f3d0 },
       });
       emptyText.anchor.set(0.5);
       emptyText.position.set(this.width / 2, (TOP_HUD_SPACE + (this.height - BOTTOM_HUD_SPACE)) / 2);
@@ -823,20 +850,16 @@ export class DominosRenderer implements GameRenderer {
         ${this.getCurrentTurnRowMarkup()}
         ${getTurnClockMarkup(this.turnClockSeconds, this.showTurnClock)}
         <div class="sidebar-stat-row">
-          <span class="sidebar-stat-label">Board tiles</span>
+          <span class="sidebar-stat-label">Tiles Played</span>
           <span class="sidebar-stat-value">${this.boardTiles.length}</span>
         </div>
         <div class="sidebar-stat-row">
           <span class="sidebar-stat-label">Boneyard</span>
-          <span class="sidebar-stat-value">${this.boneyardCount}</span>
+          <span class="sidebar-stat-value">${this.boneyardCount} tiles</span>
         </div>
         <div class="sidebar-stat-row">
           <span class="sidebar-stat-label">Open ends</span>
           <span class="sidebar-stat-value">${this.openEndA === -1 ? "—" : `${this.openEndA} | ${this.openEndB}`}</span>
-        </div>
-        <div class="sidebar-stat-row">
-          <span class="sidebar-stat-label">Status</span>
-          <span class="sidebar-stat-value">${escapeHtml(this.getSidebarStatus())}</span>
         </div>
       </div>`,
     );
@@ -863,6 +886,18 @@ export class DominosRenderer implements GameRenderer {
       playerRows.length > 0
         ? `<div class="sidebar-player-list">${playerRows.join("")}</div>`
         : `<div class="sidebar-empty">Waiting for players to join.</div>`,
+    );
+
+    // How to Play panel
+    this.sidebar.updatePanel(
+      "how-to-play",
+      `<ul class="sidebar-stat-list" style="list-style:none;padding:0;margin:0;">
+        <li class="sidebar-stat-row" style="gap:0.5rem"><span style="color:#a78bfa">•</span><span class="sidebar-stat-label" style="flex:1">Match numbers on the ends of the domino chain</span></li>
+        <li class="sidebar-stat-row" style="gap:0.5rem"><span style="color:#a78bfa">•</span><span class="sidebar-stat-label" style="flex:1">Click a domino to select it</span></li>
+        <li class="sidebar-stat-row" style="gap:0.5rem"><span style="color:#a78bfa">•</span><span class="sidebar-stat-label" style="flex:1">Click A or B markers to play on either end</span></li>
+        <li class="sidebar-stat-row" style="gap:0.5rem"><span style="color:#a78bfa">•</span><span class="sidebar-stat-label" style="flex:1">Draw from boneyard or pass if you can't play</span></li>
+        <li class="sidebar-stat-row" style="gap:0.5rem"><span style="color:#a78bfa">•</span><span class="sidebar-stat-label" style="flex:1">First to play all tiles wins!</span></li>
+      </ul>`,
     );
 
     // Controls panel
@@ -914,26 +949,6 @@ export class DominosRenderer implements GameRenderer {
     }
     const p = this.players.get(this.currentTurn);
     return p?.displayName ?? "Player";
-  }
-
-  private getSidebarStatus(): string {
-    if (this.phase === "waiting") {
-      return "Waiting for players to join.";
-    }
-    if (this.phase === "ended") {
-      return this.gameResult ? "Game over." : "Match complete.";
-    }
-    const local = this.getLocalPlayer();
-    if (!local || local.isSpectator) {
-      return "Spectating.";
-    }
-    if (this.isLocalPlayersTurn()) {
-      if (this.choosingEnd) {
-        return "Choose which end to place your tile (A or B).";
-      }
-      return "Select a tile from your hand to play.";
-    }
-    return "Waiting for opponent's move.";
   }
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/client/src/ui/LobbyScreen.ts
+++ b/client/src/ui/LobbyScreen.ts
@@ -135,6 +135,12 @@ const GAME_TYPE_OPTIONS: GameTypeOption[] = [
     playerCountLabel: "2-6 players",
     selectablePlayerCounts: [2, 3, 4, 5, 6],
   },
+  {
+    value: "dominos",
+    label: "Dominos",
+    playerCountLabel: "2-4 players",
+    selectablePlayerCounts: [2, 3, 4],
+  },
 ];
 const MAX_DISPLAY_NAME_LENGTH = 24;
 
@@ -146,6 +152,7 @@ const GAME_TILE_ARTWORK: Record<string, string> = {
   checkers: "/game-thumbnails/checkers.jpg",
   backgammon: "/game-thumbnails/backgammon.jpg",
   risk: "/game-thumbnails/risk.jpg",
+  dominos: "/game-thumbnails/dominos.jpg",
   default: "/game-thumbnails/checkers.jpg",
 };
 


### PR DESCRIPTION
## Summary

Brings the lobby and Dominos renderer into spec with the latest Figma UX export.

### Lobby (index.html + LobbyScreen.ts)
- **Color migration:** violet accent → blue accent across all lobby elements
- **Background:** dark slate gradient (slate-950 → slate-900 → slate-800)
- **Game tiles:** Added Dominos to the game type selector + artwork mapping
- **Panel styling:** Updated sidebar panels, badges, filter buttons, avatar gradients

### Dominos Renderer (DominosRenderer.ts + DesignTokens.ts)
- **Emerald board surface** with rounded rect background layer
- **"How to Play" sidebar panel** with gameplay instructions
- **Cleaner sidebar:** renamed panels, removed redundant status display
- **Board empty state:** Updated text to "Play any domino to start"

### Design Tokens
- Added `EMERALD_800`, `EMERALD_900` for Dominos board
- Section headers for emerald and slate token groups

Build/lint/test all green (430 tests passing).
