### PR TITLE
fix: dominos tile placement and preview (#155)

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -723,3 +723,37 @@ npm run test   # ✅ 467 tests passed
 **Cross-agent coordination:** No other agents involved. Standalone renderer improvements.
 
 **Status:** P7 complete. Risk phase banner now matches Figma prominence. Dominos background already correct.
+
+---
+
+## 2026-03-16: Dominos Tile Placement Bug Fix & Ghost Preview (#155)
+
+**From:** Gately
+**PR:** #158 (branch: squad/155-dominos-placement)
+
+**Problem diagnosed:**
+- End position markers used a hardcoded 8px offset from the last tile on each arm, regardless of board scale
+- At scale=1, a regular tile is 56px wide with a 4px gap, so the actual placement was ~60px from the last tile — but the marker appeared only 8px away
+- Arms A/C (negative direction) were worst: the marker hovered near the last tile while the actual tile rendered far out past it
+- No visual preview existed to show where a tile would actually land
+
+**Root cause:** `endPositions` calculation in `redrawBoardCross()` and `redrawBoardLinear()` used `± 8` instead of `± BOARD_TILE_GAP * scale`
+
+**Fix applied:**
+1. Replaced all fixed 8px end-position offsets with `BOARD_TILE_GAP * scale` for correct, scale-aware positioning
+2. Added `ghostLayer` container (between board and markers in z-order) for semi-transparent preview tiles
+3. Implemented `drawGhostTiles()` — renders alpha-0.4 tiles at exact target positions for each valid end when `choosingEnd` is true
+4. Ghost tiles compute correct dimensions (regular vs double), orientation per arm direction, and pip layout via `resolveGhostExposedEnd()`
+5. Centered end markers (A/B/C/D labels) on ghost tile area instead of directional anchor offsets
+6. Stored layout state (boardScale, spinnerCenter, armEndEdges) as instance variables for ghost computation
+
+**Files modified:** `client/src/renderers/DominosRenderer.ts`
+
+**Validation:** Build ✅, Lint ✅, Tests ✅ (506 pass)
+
+## Learnings
+
+- **Dominos end position math:** The `endPositions` dictionary stores where the NEXT tile's connecting edge would be placed. It must use scale-aware offsets (`BOARD_TILE_GAP * scale`), never fixed pixel values, because the board scales down when arms grow long.
+- **Ghost tile rendering pattern:** Store layout state (scale, center positions, arm end edges) as instance variables during `redrawBoard*()` so ghost/preview computations use the same coordinate system without re-deriving everything.
+- **Board tile ordering:** The server stores tiles in chronological (play) order with arm assignments. Post-spinner tiles within each arm are correctly ordered (closest to spinner first). Pre-spinner retroactive tiles may not match spatial order — a known server-side limitation that doesn't affect the ghost preview.
+- **`exposedEnd` field:** Represents the pip value facing outward (away from spinner) after placement. For ghost tiles, compute it by checking which pip matches the arm's open end — the other pip faces outward.

--- a/.squad/agents/ortho/history.md
+++ b/.squad/agents/ortho/history.md
@@ -270,3 +270,50 @@
 - The lobby sidebar architecture was already complete with glass-morphism panels, proper data wiring, and interactive elements (join buttons, status badges)
 - Transition timing consistency across hover effects (300ms standard) creates smoother, more cohesive UX
 
+---
+
+## 2026-07-23: HistoryScreen + View History Button — Complete ✅
+
+**Status:** Complete
+**Build:** ✅ Pass | **Lint:** ✅ Pass | **Test:** ✅ Pass (506 tests)
+
+### What was built
+
+**Created (2 new files):**
+- `client/src/ui/HistoryScreen.ts` — Full-screen DOM overlay for move history review
+  - Glass-morphism panel matching VictoryScreen visual style
+  - Header with title, game badge, close button (×)
+  - Stats bar: total moves, duration, average move time
+  - Scrollable move list with per-player color coding (up to 4 players)
+  - Turn number badges, player names, formatted descriptions, timestamps
+  - Footer with "Back to Results" button
+  - Keyboard accessible (Escape to close, focus management)
+  - `hs-` CSS class prefix to avoid conflicts
+  - z-index 10001 (above VictoryScreen's 10000)
+
+- `client/src/ui/historyFormatters.ts` — Per-game move formatting system
+  - `MoveFormatter` interface: `formatMove()` + `getMoveIcon()`
+  - Checkers formatter: move (➡️), capture (⚔️), king (👑) with A1-H8 notation
+  - Default fallback formatter using `entry.description`
+  - `getFormatter(gameType)` registry lookup
+
+**Modified:**
+- `client/src/ui/VictoryScreen.ts`
+  - Extended `VictoryScreenEvent` union with `{ type: "view_history"; gameType: string }`
+  - Enabled "View History" button (removed disabled/title, added click handler)
+  - Updated CSS: removed disabled styles, added hover effect for active button
+
+- `client/src/Application.ts`
+  - Imported HistoryScreen + HistoryScreenData
+  - Added `historyScreen` instance variable, instantiated alongside VictoryScreen
+  - Extracted `showVictoryScreenWithHistory()` method for round-trip navigation
+  - `view_history` event: hides VictoryScreen, shows HistoryScreen with moveHistory from `GameResult.metadata`, onClose re-shows VictoryScreen
+
+### Learnings
+
+- **HistoryScreen pattern:** Same `injectStyles()` pattern as VictoryScreen/PlayerInfoBar. Uses `#history-overlay` appended to document.body. Shows/hides via DOM manipulation. Escape key handler attached on show, removed on hide.
+- **Round-trip overlay navigation:** VictoryScreen → HistoryScreen → back to VictoryScreen. Done by storing victory data and re-calling `showVictoryScreenWithHistory()` on close. No scene transition needed since both are DOM overlays.
+- **Move history data flow:** `GameResult.metadata.moveHistory` is the `MoveEntry[]` array. Extracted as `Record<string, unknown>` in Application.ts, then cast.
+- **Player color coding:** Up to 4 players supported via `hs-player-{0..3}` CSS classes, assigned by order of first appearance in move history.
+- **Formatter extensibility:** Add new game formatters to the `formatters` record in `historyFormatters.ts`. Each gets a `MoveFormatter` implementation.
+

--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -706,3 +706,23 @@ Implemented standard dominos spinner rules with 4-way branching:
 - Move entry interface: `shared/src/MoveEntry.ts`
 - Plugin extension: `shared/src/gamePlugin.ts` (line ~37)
 - Recording logic: `server/src/game/BaseGameRoom.ts` (recordMove ~line 719, processAction ~line 351, endGame ~line 476)
+
+### Checkers formatMoveHistory implementation (2026-03-16)
+
+- Implemented `formatMoveHistory` on `checkersPlugin` — the first game-specific move formatter. It annotates each `MoveEntry.description` with human-readable text based on move type.
+- Description format:
+  - Regular move: `"{Name} moved from {from} to {to}"`
+  - Capture: `"{Name} captured at {to} (from {from})"`
+  - King promotion: `"{Name} kinged at {to}"`
+  - Capture + king: `"{Name} captured at {to} (from {from}), kinged at {to}"`
+  - Multi-jump chain: `"{Name} captured {N} pieces"` (updates all entries in chain with running count)
+- Coordinate notation converts board index to algebraic: col → A-H, row → 1-8 (index 0 = A1, index 63 = H8).
+- Capture detection uses row delta (abs delta === 2). King promotion checks playerIndex: BLACK (0) → row 7, RED (1) → row 0.
+- Multi-jump detection: consecutive captures by same player where prev entry's `to === current from`.
+- Edge cases: missing payload fields produce no description; unknown player IDs skip king detection; original moves array is never mutated.
+- 14 new unit tests in `server/src/games/checkers/__tests__/formatMoveHistory.test.ts`.
+- All 506 tests pass, build and lint green.
+
+**Key file paths:**
+- Formatter logic: `server/src/games/checkers/CheckersPlugin.ts` (formatMoveEntries helper + formatMoveHistory method)
+- Tests: `server/src/games/checkers/__tests__/formatMoveHistory.test.ts`

--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -666,3 +666,43 @@ Implemented standard dominos spinner rules with 4-way branching:
 **Build/Lint/Test:** ✅ All green (446 tests pass)
 
 ---
+
+## Learnings
+
+### 2026-03-18T20:30:00Z: Move History Core Infrastructure (P6.1)
+
+**Task:** Built server-side move history recording system for all games.
+
+**Architecture decisions implemented:**
+- **Storage:** Server-side only, in-memory plain array (`private moveHistory: MoveEntry[]`), NOT in Colyseus schema
+- **Delivery:** Attached to `GameResult.metadata.moveHistory` at game end (broadcast to all clients including spectators)
+- **No schema modification:** History is ephemeral, dies with room, no network sync during game
+- **CPU moves recorded:** CPU opponent actions tracked like player actions
+- **Spectator visibility:** History broadcast in game result event
+
+**Files created:**
+- `shared/src/MoveEntry.ts` — Generic move entry interface with turnNumber, playerId, playerName, actionType, payload, timestamp, optional description
+
+**Files modified:**
+- `shared/src/gamePlugin.ts` — Added optional `formatMoveHistory?(state: TState, moves: MoveEntry[]): MoveEntry[]` to GamePlugin interface
+- `shared/src/index.ts` — Exported MoveEntry type
+- `server/src/game/BaseGameRoom.ts`:
+  - Added `moveHistory: MoveEntry[]` private field
+  - Added `recordMove(actionType, sessionId, payload)` private method
+  - Added `getGameElapsedTime(): number` helper
+  - Call `recordMove()` in `processAction()` after successful action execution
+  - Reset `moveHistory = []` in `startGame()` alongside `gameStartTime`
+  - Format and attach history to `GameResult.metadata.moveHistory` in `endGame()`
+
+**Implementation patterns:**
+- Move recording happens AFTER handler success, BEFORE game end check (line ~351 in processAction)
+- Timestamp is ms since game start (using existing `this.gameStartTime`)
+- Plugin can optionally format moves via `formatMoveHistory()` hook for human-readable descriptions
+- Player name resolved from `this.state.players.get(sessionId)?.displayName ?? "Unknown"`
+
+**Build/Lint/Test:** ✅ Build clean, lint clean (0 new errors)
+
+**Key file paths:**
+- Move entry interface: `shared/src/MoveEntry.ts`
+- Plugin extension: `shared/src/gamePlugin.ts` (line ~37)
+- Recording logic: `server/src/game/BaseGameRoom.ts` (recordMove ~line 719, processAction ~line 351, endGame ~line 476)

--- a/.squad/agents/steeply/history.md
+++ b/.squad/agents/steeply/history.md
@@ -563,3 +563,48 @@ Use `getByRole("button", { name: /^✓ Ready$/ })` to avoid false matches with "
 
 **Test results:** 33/40 passing. 7 failures are pre-existing game logic issues (Backgammon state sync, Risk UI text) unrelated to setup screen migration.
 
+
+## 2026-03-17 — Move History Test Coverage (P6.1)
+
+**Status:** Complete ✅  
+**Parallel to:** Pemulis (building implementation)
+
+Wrote comprehensive test coverage for P6.1 Move History Core Infrastructure before implementation exists. Tests validate the behavior contract — once Pemulis implements the spec, they should pass.
+
+**Test file:** `server/src/__tests__/move-history.test.ts` (25 tests, 3 passing compile checks, 22 skipped pending implementation)
+
+**Test categories:**
+1. MoveEntry interface validation (3 tests) — validates type structure, optional fields, import from @eschaton/shared
+2. Move recording in game flow (5 tests) — history growth, field correctness, timestamp monotonicity, multi-jump handling, player names
+3. History delivery in GameResult (3 tests) — metadata.moveHistory presence, totalMoves count, complete history at game end
+4. History reset on new game (2 tests) — empty on start, cleared between games
+5. Plugin formatMoveHistory integration (4 tests) — formatter called, formatted vs raw history, description addition
+6. CPU move recording (2 tests) — CPU moves tracked, distinguished from human moves
+7. Edge cases (5 tests) — empty history, payload immutability, invalid moves not recorded
+8. getGameElapsedTime helper (2 tests) — elapsed time calculation, 0 before start
+
+**Architecture validated:**
+- Storage: Server-side only, in-memory (NOT Colyseus schema)
+- Delivery: via GameResult.metadata at game end
+- CPU moves ARE recorded
+- History is ephemeral — dies with room
+- Plugin can optionally format history before delivery via `formatMoveHistory()`
+
+**Key test patterns identified:**
+- Use `it.skip()` for tests that depend on implementation not yet complete
+- Follow existing `checkers-e2e.test.ts` pattern for game setup
+- Mock Colyseus Client objects with `{ sessionId } as Client`
+- Use Vitest (`describe`, `it`, `expect`, `vi` for mocks)
+- Import from `@eschaton/shared` via vi.mock() → dynamic import pattern
+- Test through plugin actions, not BaseGameRoom internals
+
+**Build status:** ✅ All tests compile, 3 passing (interface validation), 22 skipped awaiting implementation
+
+**Learnings:**
+- Test-driven approach works well for parallel development — tests define the contract, implementation fills it in
+- Skipped tests serve as executable documentation of expected behavior
+- MoveEntry timestamp should be monotonically increasing (not strictly increasing) to handle fast CPU moves
+- Multi-jump moves in Checkers create multiple history entries with same turnNumber
+- Payload immutability is important — history should deep-copy payloads, not store references
+- Invalid moves should NOT be recorded in history
+- formatMoveHistory is optional — plugins that don't provide it get raw history

--- a/.squad/decisions/inbox/gately-dominos-placement.md
+++ b/.squad/decisions/inbox/gately-dominos-placement.md
@@ -1,0 +1,20 @@
+# Gately: Dominos End-Position and Ghost Preview Pattern
+
+**Status:** Proposed
+**Date:** 2026-03-16
+**PR:** #158
+
+## Decision
+
+End-position markers and placement previews in dominos (and any future tile/card game) must use scale-aware offsets derived from layout constants (`BOARD_TILE_GAP * scale`), never fixed pixel values. Ghost tile previews should render at the exact computed placement position using the same coordinate system as the board layout.
+
+## Rationale
+
+- Fixed-pixel offsets (the previous `± 8px`) diverge from actual tile placement at any scale other than exactly 1.0, and even at scale=1 they're wrong (gap is 4px, not 8px). This causes the "tiles placed in wrong position" perception.
+- Storing layout state (scale, spinner center, arm end edges) as instance variables lets ghost preview and marker logic reuse the same coordinate math without re-deriving the entire layout.
+- The ghost tile preview (alpha 0.4) gives players immediate visual feedback on where a tile will land and how it will be oriented, replacing the ambiguous directional markers.
+
+## Impact
+
+- Pattern applies to any future renderer that shows placement previews or position indicators on a scaled board.
+- Ghost tiles are drawn in a dedicated `ghostLayer` between the board and markers in z-order, keeping render responsibilities separated.

--- a/.squad/decisions/inbox/ortho-history-screen.md
+++ b/.squad/decisions/inbox/ortho-history-screen.md
@@ -1,0 +1,31 @@
+# Decision: HistoryScreen Overlay Architecture
+
+**Date:** 2026-07-23
+**Author:** Ortho (Frontend Dev)
+**Status:** Implemented
+
+## Context
+
+P6.1 delivered server-side move history recording. The VictoryScreen had a disabled "View History" button placeholder. Task was to build the HistoryScreen UI and wire it up.
+
+## Decision
+
+### 1. DOM overlay, not a scene
+HistoryScreen is a DOM overlay (same as VictoryScreen), not a PixiJS scene. This keeps it consistent with all other UI overlays and avoids canvas lifecycle complexity.
+
+### 2. Round-trip navigation via callbacks
+VictoryScreen → HistoryScreen → VictoryScreen is handled by storing the victory data and re-calling `showVictoryScreenWithHistory()` on close. No scene transitions involved — both are DOM overlays that append/remove from `document.body`.
+
+### 3. z-index layering
+HistoryScreen uses z-index 10001 (one above VictoryScreen at 10000). This ensures it stacks correctly when both exist momentarily.
+
+### 4. Formatter registry pattern
+`historyFormatters.ts` uses a simple `Record<string, MoveFormatter>` registry with a `getFormatter()` lookup. New game formatters are added by inserting into the record. The checkers formatter demonstrates the pattern; other games can be added as needed.
+
+### 5. Player color coding via appearance order
+Players are assigned color indices (0–3) based on order of first appearance in the move history, not by session ID. This ensures stable, deterministic colors regardless of Colyseus session IDs.
+
+## Impact
+
+- **Pemulis (Game Logic):** When adding formatters for backgammon/risk/dominos, add entries to the `formatters` record in `client/src/ui/historyFormatters.ts`.
+- **Server team:** No changes needed. Move history is read from `GameResult.metadata.moveHistory`.

--- a/.squad/decisions/inbox/pemulis-checkers-formatter.md
+++ b/.squad/decisions/inbox/pemulis-checkers-formatter.md
@@ -1,0 +1,33 @@
+# Decision: Checkers Move Formatter — Description Format Convention
+
+**Author:** Pemulis  
+**Date:** 2026-03-16  
+**Status:** Implemented
+
+## Context
+
+P6.1 built the generic move history infrastructure (MoveEntry, recordMove, delivery via GameResult.metadata). The CheckersPlugin is the first game to implement `formatMoveHistory`, establishing the pattern other games will follow.
+
+## Decision
+
+Adopted a description format convention for Checkers move history:
+
+- **Regular move:** `"{PlayerName} moved from {from} to {to}"`
+- **Capture:** `"{PlayerName} captured at {to} (from {from})"`
+- **King promotion:** `"{PlayerName} kinged at {to}"`
+- **Capture + promotion:** `"{PlayerName} captured at {to} (from {from}), kinged at {to}"`
+- **Multi-jump chain:** `"{PlayerName} captured {N} pieces"` — all entries in the chain share the same description with the running count
+
+Coordinate notation: board index → algebraic (A1–H8), column = index % 8 → letter, row = floor(index / 8) + 1.
+
+## Rationale
+
+- Human-readable descriptions serve the game result screen and any future replay/export features.
+- Multi-jump chains consolidate into a single summary because individual hop descriptions would be noisy in the UI.
+- Move type detection is payload-based (row delta for captures, destination row for promotion) rather than replaying game state, which keeps the formatter stateless with respect to board evolution.
+- Unknown players and missing payload fields produce graceful fallbacks (no description) rather than errors.
+
+## Impact
+
+- Other game plugins (Backgammon, Risk, Dominoes) should follow this pattern: implement `formatMoveHistory` with game-appropriate description strings.
+- The formatter is pure — it doesn't mutate inputs and can be unit-tested without Colyseus room infrastructure.

--- a/.squad/decisions/inbox/pemulis-p6-core-infra.md
+++ b/.squad/decisions/inbox/pemulis-p6-core-infra.md
@@ -1,0 +1,45 @@
+# Decision: Move History Core Infrastructure
+
+**Date:** 2026-03-18  
+**Decider:** Pemulis (Systems Dev)  
+**Context:** P6.1 — Build server-side move history recording system
+
+## Decision
+
+Implemented in-memory, server-side-only move history recording with delivery via `GameResult.metadata` at game end.
+
+## Architecture
+
+- **Storage:** Plain JS array `moveHistory: MoveEntry[]` in BaseGameRoom (NOT Colyseus schema)
+- **Recording:** Captured in `processAction()` after successful action execution
+- **Delivery:** Attached to `GameResult.metadata.moveHistory` during `endGame()` broadcast
+- **Formatting:** Optional plugin hook `formatMoveHistory()` for game-specific human-readable descriptions
+
+## Rationale
+
+- In-memory storage avoids schema sync overhead (no per-move network traffic)
+- Ephemeral history (dies with room) is acceptable — game results persist in DB
+- Recording after handler success ensures only valid moves are logged
+- CPU moves and spectators supported automatically (broadcast to all at game end)
+
+## Alternatives Considered
+
+- Colyseus `ArraySchema` — Rejected: Real-time sync not needed, adds network/CPU overhead
+- External logging service — Rejected: Overkill for MVP, adds latency
+- Client-side only — Rejected: Source of truth must be server
+
+## Impact
+
+- All 4 games (Checkers, Backgammon, Risk, Dominos) can use this infrastructure
+- Game plugins can opt-in to formatting via `formatMoveHistory()` hook
+- No breaking changes — optional feature, backward compatible
+
+## Implementation Files
+
+- `shared/src/MoveEntry.ts` — Interface definition
+- `shared/src/gamePlugin.ts` — Added formatMoveHistory optional method
+- `server/src/game/BaseGameRoom.ts` — Recording logic + delivery
+
+## Status
+
+✅ Complete — Build clean, lint clean, ready for game-specific implementations (P6.2-P6.5)

--- a/.squad/decisions/inbox/steeply-p6-test-strategy.md
+++ b/.squad/decisions/inbox/steeply-p6-test-strategy.md
@@ -1,0 +1,65 @@
+# P6.1 Move History Test Strategy
+
+**Agent:** Steeply  
+**Date:** 2026-03-17  
+**Context:** Writing tests for move history system being built by Pemulis in parallel
+
+## Decision: Test-Before-Implementation Pattern for Parallel Development
+
+When writing tests for a feature being implemented in parallel by another agent:
+
+1. **Write comprehensive test stubs using `it.skip()`** for tests that depend on implementation
+   - Allows TypeScript compilation and validates test structure
+   - Serves as executable documentation of expected behavior
+   - Can be unskipped incrementally as implementation progresses
+
+2. **Keep passing tests for interface/type validation** that don't require runtime implementation
+   - MoveEntry type structure validation
+   - Import checks
+   - Contract validation with mock data
+
+3. **Follow existing test patterns** from the codebase
+   - Use same setup helpers (createStartedGame, performMove, etc.)
+   - Match import patterns (vi.mock + dynamic import)
+   - Use same assertion style
+
+4. **Test the contract, not the implementation**
+   - Don't assume internal implementation details
+   - Test through public plugin interfaces
+   - Focus on observable behavior (GameResult metadata, state changes)
+
+## Key Test Patterns Established
+
+### For Move History Tests:
+- Test MoveEntry structure first (validates types compile)
+- Test move recording through game actions (integration style)
+- Test history delivery through GameResult
+- Test edge cases: empty history, invalid moves, CPU moves
+- Test plugin integration points: formatMoveHistory()
+
+### For Game State Tests:
+- Use plugin actions as the entry point
+- Validate state changes through schema properties
+- Use helper functions to create controlled game states
+- Test multi-step sequences (multi-jump moves)
+
+## Benefits of This Approach
+
+1. **Parallel efficiency** — Tester and implementer work simultaneously
+2. **Clear contract** — Tests document expected behavior before implementation
+3. **Early compilation** — Catches type errors immediately
+4. **Incremental validation** — Unskip tests as implementation progresses
+5. **Regression protection** — Tests are ready when implementation merges
+
+## Applying This Pattern
+
+Use this pattern when:
+- Multiple agents working on related features
+- Architecture/spec is clear but implementation is in progress
+- Test coverage is critical for the feature
+- You want executable documentation of expected behavior
+
+Avoid when:
+- Architecture is still being explored
+- Spec is likely to change significantly
+- Implementation details will inform test design

--- a/client/src/Application.ts
+++ b/client/src/Application.ts
@@ -35,6 +35,7 @@ import { SandboxScene } from "./scenes/SandboxScene";
 import { ReconnectOverlay } from "./ui/ReconnectOverlay";
 import { GameOverOverlay } from "./ui/GameOverOverlay";
 import { VictoryScreen, type VictoryScreenEvent, type VictoryPlayerInfo } from "./ui/VictoryScreen";
+import { HistoryScreen, type HistoryScreenData } from "./ui/HistoryScreen";
 import { ConsoleLog } from "./ui/ConsoleLog";
 import { JOIN_GAME, type JoinGamePayload, type LobbyEvent } from "./ui/LobbyScreen";
 import { GAME_LAYOUT_CHANGE_EVENT } from "./ui/gameLayout";
@@ -98,6 +99,7 @@ export class PlaygridApp {
   private reconnectOverlay!: ReconnectOverlay;
   private gameOverOverlay!: GameOverOverlay;
   private victoryScreen!: VictoryScreen;
+  private historyScreen!: HistoryScreen;
   private consoleLog!: ConsoleLog;
   private statusHideTimeoutId: number | null = null;
   private reconnectOverlayHideTimeoutId: number | null = null;
@@ -201,6 +203,7 @@ export class PlaygridApp {
     this.reconnectOverlay = new ReconnectOverlay();
     this.gameOverOverlay = new GameOverOverlay();
     this.victoryScreen = new VictoryScreen();
+    this.historyScreen = new HistoryScreen();
     this.consoleLog = new ConsoleLog();
     this.lobbyScene.setConsoleLog(this.consoleLog);
     window.addEventListener("beforeunload", () => this.persistSessionForRefresh());
@@ -450,6 +453,7 @@ export class PlaygridApp {
     const sessionId = this.gameRoom?.sessionId ?? "";
     const gameType = this.activeGameType ?? this.gameRoom?.name ?? "checkers";
     const players = this.extractVictoryPlayers();
+    const victoryData = { result, sessionId, gameType, players };
 
     const endMsg = result.type === "win"
       ? (result.winnerId === sessionId ? "Victory! You won the game." : "Defeat — opponent wins.")
@@ -462,13 +466,31 @@ export class PlaygridApp {
             : "Game over.";
     this.consoleLog?.log(endMsg, result.winnerId === sessionId ? "success" : "info");
 
-    this.victoryScreen.show(
-      { result, sessionId, gameType, players },
-      (event: VictoryScreenEvent) => {
+    this.showVictoryScreenWithHistory(victoryData);
+  }
+
+  private showVictoryScreenWithHistory(
+    victoryData: { result: GameResult; sessionId: string; gameType: string; players: VictoryPlayerInfo[] },
+  ): void {
+    this.victoryScreen.show(victoryData, (event: VictoryScreenEvent) => {
+      if (event.type === "view_history") {
         this.victoryScreen.hide();
-        void this.handleVictoryEvent(event);
-      },
-    );
+        const meta = (victoryData.result.metadata ?? {}) as Record<string, unknown>;
+        const moveHistory = (Array.isArray(meta.moveHistory) ? meta.moveHistory : []) as import("@eschaton/shared").MoveEntry[];
+        const historyData: HistoryScreenData = {
+          moveHistory,
+          gameType: victoryData.gameType,
+          metadata: meta,
+        };
+        this.historyScreen.show(historyData, () => {
+          this.showVictoryScreenWithHistory(victoryData);
+        });
+        return;
+      }
+
+      this.victoryScreen.hide();
+      void this.handleVictoryEvent(event);
+    });
   }
 
   private async handleVictoryEvent(event: VictoryScreenEvent): Promise<void> {

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -999,14 +999,20 @@ export class DominosRenderer implements GameRenderer {
       // Vertical divider
       g.moveTo(x + w / 2, y + 1).lineTo(x + w / 2, y + h - 1).stroke({ color: TILE_DIVIDER_COLOR, width: 1 });
       const halfW = w / 2;
-      this.drawPipsHorizontal(g, tile.highPips, x, y, halfW, h, scale);
-      this.drawPipsHorizontal(g, tile.lowPips, x + halfW, y, halfW, h, scale);
+      // Draw pips based on exposedEnd: the exposed end faces the chain's left/start
+      const leftPips = tile.exposedEnd === tile.highPips ? tile.highPips : tile.lowPips;
+      const rightPips = tile.exposedEnd === tile.highPips ? tile.lowPips : tile.highPips;
+      this.drawPipsHorizontal(g, leftPips, x, y, halfW, h, scale);
+      this.drawPipsHorizontal(g, rightPips, x + halfW, y, halfW, h, scale);
     } else {
       // Horizontal divider
       g.moveTo(x + 1, y + h / 2).lineTo(x + w - 1, y + h / 2).stroke({ color: TILE_DIVIDER_COLOR, width: 1 });
       const halfH = h / 2;
-      this.drawBoardPipsVertical(g, tile.highPips, x, y, w, halfH, scale);
-      this.drawBoardPipsVertical(g, tile.lowPips, x, y + halfH, w, halfH, scale);
+      // Draw pips based on exposedEnd: the exposed end faces the chain's top/start
+      const topPips = tile.exposedEnd === tile.highPips ? tile.highPips : tile.lowPips;
+      const bottomPips = tile.exposedEnd === tile.highPips ? tile.lowPips : tile.highPips;
+      this.drawBoardPipsVertical(g, topPips, x, y, w, halfH, scale);
+      this.drawBoardPipsVertical(g, bottomPips, x, y + halfH, w, halfH, scale);
     }
   }
 

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -138,6 +138,7 @@ export class DominosRenderer implements GameRenderer {
   // ── Layers ──────────────────────────────────────────────────────────────
   private readonly boardBackground = new Graphics();
   private readonly boardLayer = new Container();
+  private readonly ghostLayer = new Container();
   private readonly handLayer = new Container();
   private readonly overlayLayer = new Container();
   private readonly overlayBackground = new Graphics();
@@ -222,6 +223,19 @@ export class DominosRenderer implements GameRenderer {
   private width = DEFAULT_WIDTH;
   private height = DEFAULT_HEIGHT;
 
+  // Layout state (stored during redraw for ghost tile computation)
+  private boardScale = 1;
+  private crossSpinnerCX = 0;
+  private crossSpinnerCY = 0;
+  private crossArmAEndX = 0;
+  private crossArmBEndX = 0;
+  private crossArmCEndY = 0;
+  private crossArmDEndY = 0;
+  private linearStartX = 0;
+  private linearChainWidth = 0;
+  private linearCenterY = 0;
+  private layoutMode: "empty" | "linear" | "cross" = "empty";
+
   constructor() {
     this.overlayLayer.eventMode = "none";
     this.overlayLayer.visible = false;
@@ -252,6 +266,7 @@ export class DominosRenderer implements GameRenderer {
     this.container.addChild(
       this.boardBackground,
       this.boardLayer,
+      this.ghostLayer,
       this.endMarkerA,
       this.endMarkerB,
       this.endMarkerC,
@@ -343,6 +358,7 @@ export class DominosRenderer implements GameRenderer {
     this.sidebar?.destroy();
     this.sidebar = null;
     this.boardLayer.removeChildren();
+    this.ghostLayer.removeChildren();
     this.handLayer.removeChildren();
     this.validEnds = [];
     this.container.destroy({ children: true });
@@ -557,6 +573,7 @@ export class DominosRenderer implements GameRenderer {
   private redrawAll(): void {
     this.redrawBoardBackground();
     this.redrawBoard();
+    this.drawGhostTiles();
     this.redrawHand();
     this.redrawBoneyard();
     this.redrawEndMarkers();
@@ -594,6 +611,7 @@ export class DominosRenderer implements GameRenderer {
     this.boardLayer.removeChildren();
 
     if (this.boardTiles.length === 0) {
+      this.layoutMode = "empty";
       const emptyText = new Text({
         text: "Play any domino to start",
         style: { fontFamily: "sans-serif", fontSize: 16, fill: 0xa7f3d0 },
@@ -613,6 +631,7 @@ export class DominosRenderer implements GameRenderer {
 
   /** Pre-spinner horizontal chain (original layout) */
   private redrawBoardLinear(): void {
+    this.layoutMode = "linear";
     const availableWidth = this.width - VIEW_PADDING * 2;
     const availableHeight = this.height - TOP_HUD_SPACE - BOTTOM_HUD_SPACE;
     const tileStride = BOARD_TILE_W + BOARD_TILE_GAP;
@@ -621,6 +640,11 @@ export class DominosRenderer implements GameRenderer {
     const scale = totalChainWidth > availableWidth ? availableWidth / totalChainWidth : 1;
     const startX = this.width / 2 - (totalChainWidth * scale) / 2;
     const centerY = TOP_HUD_SPACE + availableHeight / 2;
+
+    this.boardScale = scale;
+    this.linearStartX = startX;
+    this.linearChainWidth = totalChainWidth;
+    this.linearCenterY = centerY;
 
     for (let i = 0; i < this.boardTiles.length; i++) {
       const bt = this.boardTiles[i];
@@ -634,16 +658,18 @@ export class DominosRenderer implements GameRenderer {
       this.boardLayer.addChild(g);
     }
 
-    // Store end positions for markers
+    // End positions at the gap edge where a new tile's connecting side would be
+    const chainRightEdge = startX + totalChainWidth * scale;
     const endY = centerY;
-    this.endPositions.a = { x: startX - 8, y: endY };
-    this.endPositions.b = { x: startX + totalChainWidth * scale + 8, y: endY };
+    this.endPositions.a = { x: startX - BOARD_TILE_GAP * scale, y: endY };
+    this.endPositions.b = { x: chainRightEdge + BOARD_TILE_GAP * scale, y: endY };
     this.endPositions.c = { x: this.width / 2, y: centerY };
     this.endPositions.d = { x: this.width / 2, y: centerY };
   }
 
   /** Post-spinner cross layout with 4-way branching */
   private redrawBoardCross(): void {
+    this.layoutMode = "cross";
     const spinner = this.boardTiles.find((t) => t.arm === "spinner");
     const armATiles = this.boardTiles.filter((t) => t.arm === "a");
     const armBTiles = this.boardTiles.filter((t) => t.arm === "b");
@@ -679,11 +705,16 @@ export class DominosRenderer implements GameRenderer {
     const scaleY = totalH > availableHeight ? availableHeight / totalH : 1;
     const scale = Math.min(scaleX, scaleY, 1);
 
+    this.boardScale = scale;
+
     // Position cross centered in available area
     const crossLeft = (this.width - totalW * scale) / 2;
     const crossTop = TOP_HUD_SPACE + (availableHeight - totalH * scale) / 2;
     const spinnerCX = crossLeft + (armAExtent + leftPad) * scale + (spinnerW * scale) / 2;
     const spinnerCY = crossTop + (armCExtent + topPad) * scale + (spinnerH * scale) / 2;
+
+    this.crossSpinnerCX = spinnerCX;
+    this.crossSpinnerCY = spinnerCY;
 
     // Draw spinner
     const sX = spinnerCX - (spinnerW * scale) / 2;
@@ -755,11 +786,16 @@ export class DominosRenderer implements GameRenderer {
     }
     const armDEndY = armDTiles.length > 0 ? cursorY - BOARD_TILE_GAP * scale : sY + spinnerH * scale;
 
-    // Store end positions for markers
-    this.endPositions.a = { x: armAEndX - 8, y: spinnerCY };
-    this.endPositions.b = { x: armBEndX + 8, y: spinnerCY };
-    this.endPositions.c = { x: spinnerCX, y: armCEndY - 8 };
-    this.endPositions.d = { x: spinnerCX, y: armDEndY + 8 };
+    // Store arm end edges and compute end positions at the gap beyond the last tile
+    this.crossArmAEndX = armAEndX;
+    this.crossArmBEndX = armBEndX;
+    this.crossArmCEndY = armCEndY;
+    this.crossArmDEndY = armDEndY;
+
+    this.endPositions.a = { x: armAEndX - BOARD_TILE_GAP * scale, y: spinnerCY };
+    this.endPositions.b = { x: armBEndX + BOARD_TILE_GAP * scale, y: spinnerCY };
+    this.endPositions.c = { x: spinnerCX, y: armCEndY - BOARD_TILE_GAP * scale };
+    this.endPositions.d = { x: spinnerCX, y: armDEndY + BOARD_TILE_GAP * scale };
   }
 
   // ── Arm dimension helpers ──────────────────────────────────────────────────
@@ -796,6 +832,142 @@ export class DominosRenderer implements GameRenderer {
       total += this.getVArmTileH(t) + BOARD_TILE_GAP;
     }
     return total - BOARD_TILE_GAP;
+  }
+
+  // ── Ghost tile preview ─────────────────────────────────────────────────────
+
+  private drawGhostTiles(): void {
+    this.ghostLayer.removeChildren();
+
+    if (!this.choosingEnd || this.selectedTileId === null || this.boardTiles.length === 0) {
+      return;
+    }
+
+    const tile = this.getMyHand().find((t) => t.id === this.selectedTileId);
+    if (!tile) {
+      return;
+    }
+
+    const scale = this.boardScale;
+    const isDouble = tile.highPips === tile.lowPips;
+
+    for (const end of this.validEnds) {
+      const ghost = this.computeGhostRect(end, isDouble, scale);
+      if (!ghost) continue;
+
+      const openEnd = this.getOpenEndForArm(end);
+      const exposedEnd = this.resolveGhostExposedEnd(tile, openEnd);
+
+      const ghostTile: BoardTileSnapshot = {
+        id: -1,
+        highPips: tile.highPips,
+        lowPips: tile.lowPips,
+        exposedEnd,
+        arm: end,
+        isDouble,
+      };
+
+      const g = new Graphics();
+      g.alpha = 0.4;
+      this.drawBoardTile(g, ghostTile, ghost.x, ghost.y, ghost.w, ghost.h, ghost.orientation, scale);
+      g.eventMode = "none";
+      this.ghostLayer.addChild(g);
+    }
+  }
+
+  private computeGhostRect(
+    end: "a" | "b" | "c" | "d",
+    isDouble: boolean,
+    scale: number,
+  ): { x: number; y: number; w: number; h: number; orientation: "horizontal" | "vertical" } | null {
+    if (this.layoutMode === "linear") {
+      return this.computeLinearGhostRect(end, isDouble, scale);
+    }
+    if (this.layoutMode === "cross") {
+      return this.computeCrossGhostRect(end, isDouble, scale);
+    }
+    return null;
+  }
+
+  private computeLinearGhostRect(
+    end: "a" | "b",
+    isDouble: boolean,
+    scale: number,
+  ): { x: number; y: number; w: number; h: number; orientation: "horizontal" | "vertical" } | null {
+    // Linear layout: all tiles horizontal, doubles stay horizontal
+    const tw = BOARD_TILE_W * scale;
+    const th = BOARD_TILE_H * scale;
+    const centerY = this.linearCenterY;
+
+    if (end === "a") {
+      // Ghost extends LEFT from chain start
+      const x = this.endPositions.a.x - tw;
+      const y = centerY - th / 2;
+      return { x, y, w: tw, h: th, orientation: "horizontal" };
+    }
+    if (end === "b") {
+      // Ghost extends RIGHT from chain end
+      const x = this.endPositions.b.x;
+      const y = centerY - th / 2;
+      return { x, y, w: tw, h: th, orientation: "horizontal" };
+    }
+    return null;
+  }
+
+  private computeCrossGhostRect(
+    end: "a" | "b" | "c" | "d",
+    isDouble: boolean,
+    scale: number,
+  ): { x: number; y: number; w: number; h: number; orientation: "horizontal" | "vertical" } {
+    const sCX = this.crossSpinnerCX;
+    const sCY = this.crossSpinnerCY;
+    const pos = this.endPositions[end];
+
+    if (end === "a" || end === "b") {
+      // Horizontal arm: doubles are vertical, regulars are horizontal
+      const tw = (isDouble ? BOARD_TILE_H : BOARD_TILE_W) * scale;
+      const th = (isDouble ? BOARD_TILE_W : BOARD_TILE_H) * scale;
+      const orientation = isDouble ? "vertical" : "horizontal";
+      const y = sCY - th / 2;
+
+      if (end === "a") {
+        // Extends LEFT: ghost right edge at pos.x
+        return { x: pos.x - tw, y, w: tw, h: th, orientation };
+      }
+      // Extends RIGHT: ghost left edge at pos.x
+      return { x: pos.x, y, w: tw, h: th, orientation };
+    }
+
+    // Vertical arm: doubles are horizontal, regulars are vertical
+    const tw = (isDouble ? BOARD_TILE_W : BOARD_TILE_H) * scale;
+    const th = (isDouble ? BOARD_TILE_H : BOARD_TILE_W) * scale;
+    const orientation = isDouble ? "horizontal" : "vertical";
+    const x = sCX - tw / 2;
+
+    if (end === "c") {
+      // Extends UP: ghost bottom edge at pos.y
+      return { x, y: pos.y - th, w: tw, h: th, orientation };
+    }
+    // Extends DOWN: ghost top edge at pos.y
+    return { x, y: pos.y, w: tw, h: th, orientation };
+  }
+
+  private getOpenEndForArm(end: "a" | "b" | "c" | "d"): number {
+    switch (end) {
+      case "a": return this.openEndA;
+      case "b": return this.openEndB;
+      case "c": return this.openEndC;
+      case "d": return this.openEndD;
+    }
+  }
+
+  /** Determine which pip value faces outward on the ghost tile */
+  private resolveGhostExposedEnd(tile: HandTile, openEnd: number): number {
+    if (tile.highPips === tile.lowPips) return tile.highPips;
+    if (openEnd === -1) return tile.lowPips;
+    // The matching pip connects inward; the other pip faces outward
+    if (tile.highPips === openEnd) return tile.lowPips;
+    return tile.highPips;
   }
 
   // ── Board tile drawing ─────────────────────────────────────────────────────
@@ -888,34 +1060,24 @@ export class DominosRenderer implements GameRenderer {
     this.endMarkerC.visible = false;
     this.endMarkerD.visible = false;
 
-    if (!this.choosingEnd || this.boardTiles.length === 0) {
+    if (!this.choosingEnd || this.boardTiles.length === 0 || this.selectedTileId === null) {
       return;
     }
 
+    const tile = this.getMyHand().find((t) => t.id === this.selectedTileId);
+    if (!tile) {
+      return;
+    }
+
+    const scale = this.boardScale;
+    const isDouble = tile.highPips === tile.lowPips;
     const markerSize = 32;
 
-    const drawMarker = (marker: Graphics, label: string, pos: { x: number; y: number }, anchor: "left" | "right" | "top" | "bottom") => {
-      let mX: number;
-      let mY: number;
-
-      switch (anchor) {
-        case "left":
-          mX = pos.x - markerSize;
-          mY = pos.y - markerSize / 2;
-          break;
-        case "right":
-          mX = pos.x;
-          mY = pos.y - markerSize / 2;
-          break;
-        case "top":
-          mX = pos.x - markerSize / 2;
-          mY = pos.y - markerSize;
-          break;
-        case "bottom":
-          mX = pos.x - markerSize / 2;
-          mY = pos.y;
-          break;
-      }
+    const drawMarkerCentered = (marker: Graphics, label: string, ghostRect: { x: number; y: number; w: number; h: number }) => {
+      const centerX = ghostRect.x + ghostRect.w / 2;
+      const centerY = ghostRect.y + ghostRect.h / 2;
+      const mX = centerX - markerSize / 2;
+      const mY = centerY - markerSize / 2;
 
       marker.roundRect(mX, mY, markerSize, markerSize, 6)
         .fill({ color: END_MARKER_COLOR, alpha: END_MARKER_ACTIVE_ALPHA })
@@ -926,22 +1088,21 @@ export class DominosRenderer implements GameRenderer {
         style: { fontFamily: "sans-serif", fontSize: END_LABEL_FONT_SIZE, fontWeight: "700", fill: WHITE },
       });
       text.anchor.set(0.5);
-      text.position.set(mX + markerSize / 2, mY + markerSize / 2);
+      text.position.set(centerX, centerY);
       marker.addChild(text);
       marker.visible = true;
     };
 
-    if (this.validEnds.includes("a")) {
-      drawMarker(this.endMarkerA, "← A", this.endPositions.a, "left");
-    }
-    if (this.validEnds.includes("b")) {
-      drawMarker(this.endMarkerB, "B →", this.endPositions.b, "right");
-    }
-    if (this.validEnds.includes("c")) {
-      drawMarker(this.endMarkerC, "↑ C", this.endPositions.c, "top");
-    }
-    if (this.validEnds.includes("d")) {
-      drawMarker(this.endMarkerD, "D ↓", this.endPositions.d, "bottom");
+    for (const end of this.validEnds) {
+      const ghost = this.computeGhostRect(end, isDouble, scale);
+      if (!ghost) continue;
+
+      switch (end) {
+        case "a": drawMarkerCentered(this.endMarkerA, "← A", ghost); break;
+        case "b": drawMarkerCentered(this.endMarkerB, "B →", ghost); break;
+        case "c": drawMarkerCentered(this.endMarkerC, "↑ C", ghost); break;
+        case "d": drawMarkerCentered(this.endMarkerD, "D ↓", ghost); break;
+      }
     }
   }
 

--- a/client/src/ui/HistoryScreen.ts
+++ b/client/src/ui/HistoryScreen.ts
@@ -1,0 +1,533 @@
+import type { MoveEntry } from "@eschaton/shared";
+import { getFormatter } from "./historyFormatters";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STYLE_ID = "playgrid-history-screen-styles";
+const CONTAINER_ID = "history-overlay";
+
+const GAME_LABELS: Record<string, string> = {
+  checkers: "Checkers",
+  backgammon: "Backgammon",
+  risk: "Risk",
+  dominos: "Dominos",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HistoryScreenData {
+  moveHistory: MoveEntry[];
+  gameType: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function formatTimestamp(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const mins = Math.floor(totalSec / 60);
+  const secs = totalSec % 60;
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Style injection
+// ---------------------------------------------------------------------------
+
+function injectStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    @keyframes hs-fade-in {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
+    @keyframes hs-slide-up {
+      from { opacity: 0; transform: translateY(30px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    #${CONTAINER_ID} {
+      position: fixed;
+      inset: 0;
+      z-index: 10001;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--overlay-bg);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      animation: hs-fade-in 0.3s ease-out;
+      padding: var(--space-lg);
+    }
+
+    .hs-container {
+      width: 100%;
+      max-width: 720px;
+      max-height: 90vh;
+      display: flex;
+      flex-direction: column;
+      background: var(--glass-bg);
+      backdrop-filter: blur(var(--glass-blur));
+      -webkit-backdrop-filter: blur(var(--glass-blur));
+      border: 1px solid var(--glass-border);
+      border-radius: var(--glass-radius);
+      box-shadow: var(--shadow-modal);
+      animation: hs-slide-up 0.4s ease-out 0.05s both;
+      overflow: hidden;
+    }
+
+    /* Header */
+    .hs-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--space-md) var(--space-lg);
+      border-bottom: 1px solid var(--border-light);
+      flex-shrink: 0;
+    }
+
+    .hs-title-group {
+      display: flex;
+      align-items: center;
+      gap: var(--space-sm);
+    }
+
+    .hs-title {
+      font-family: var(--font-family);
+      font-size: var(--font-2xl);
+      font-weight: 800;
+      color: var(--text-primary);
+      margin: 0;
+    }
+
+    .hs-game-badge {
+      display: inline-block;
+      font-family: var(--font-family);
+      font-size: var(--font-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-muted);
+      background: var(--bg-card-dark);
+      padding: var(--space-2xs) var(--space-sm);
+      border-radius: var(--radius-pill);
+      border: 1px solid var(--border-light);
+    }
+
+    .hs-close {
+      width: 36px;
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: 1px solid var(--border-light);
+      border-radius: var(--radius-md);
+      color: var(--text-muted);
+      font-size: var(--font-xl);
+      cursor: pointer;
+      transition: background 0.15s ease, color 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    .hs-close:hover {
+      background: var(--pg-slate-700);
+      color: var(--text-primary);
+    }
+
+    /* Stats bar */
+    .hs-stats {
+      display: flex;
+      gap: var(--space-lg);
+      padding: var(--space-sm) var(--space-lg);
+      border-bottom: 1px solid var(--border-light);
+      flex-shrink: 0;
+      flex-wrap: wrap;
+    }
+
+    .hs-stat-item {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2xs);
+      font-family: var(--font-family);
+      font-size: var(--font-sm);
+      color: var(--text-muted);
+    }
+
+    .hs-stat-value {
+      font-weight: 700;
+      color: var(--text-secondary);
+    }
+
+    /* Move list */
+    .hs-move-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: var(--space-sm) var(--space-lg);
+      scroll-behavior: smooth;
+    }
+
+    .hs-move-list::-webkit-scrollbar {
+      width: 6px;
+    }
+    .hs-move-list::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    .hs-move-list::-webkit-scrollbar-thumb {
+      background: var(--pg-slate-600);
+      border-radius: var(--radius-pill);
+    }
+
+    .hs-empty {
+      text-align: center;
+      padding: var(--space-2xl);
+      font-family: var(--font-family);
+      font-size: var(--font-base);
+      color: var(--text-muted);
+    }
+
+    .hs-move-entry {
+      display: flex;
+      align-items: center;
+      gap: var(--space-sm);
+      padding: var(--space-xs) var(--space-sm);
+      border-radius: var(--radius-md);
+      transition: background 0.1s ease;
+    }
+
+    .hs-move-entry:hover {
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .hs-move-entry + .hs-move-entry {
+      border-top: 1px solid rgba(51, 65, 85, 0.2);
+    }
+
+    .hs-move-turn {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-family);
+      font-size: var(--font-xs);
+      font-weight: 700;
+      border-radius: var(--radius-md);
+      color: var(--text-primary);
+    }
+
+    .hs-move-turn.hs-player-0 {
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.1));
+      border: 1px solid rgba(59, 130, 246, 0.3);
+    }
+
+    .hs-move-turn.hs-player-1 {
+      background: linear-gradient(135deg, rgba(234, 179, 8, 0.25), rgba(234, 179, 8, 0.1));
+      border: 1px solid rgba(234, 179, 8, 0.3);
+    }
+
+    .hs-move-turn.hs-player-2 {
+      background: linear-gradient(135deg, rgba(168, 85, 247, 0.25), rgba(168, 85, 247, 0.1));
+      border: 1px solid rgba(168, 85, 247, 0.3);
+    }
+
+    .hs-move-turn.hs-player-3 {
+      background: linear-gradient(135deg, rgba(34, 197, 94, 0.25), rgba(34, 197, 94, 0.1));
+      border: 1px solid rgba(34, 197, 94, 0.3);
+    }
+
+    .hs-move-body {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .hs-move-player {
+      font-family: var(--font-family);
+      font-size: var(--font-xs);
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .hs-move-player.hs-player-0 { color: var(--pg-blue-400); }
+    .hs-move-player.hs-player-1 { color: var(--pg-amber-400); }
+    .hs-move-player.hs-player-2 { color: rgba(168, 85, 247, 0.9); }
+    .hs-move-player.hs-player-3 { color: var(--pg-green-400); }
+
+    .hs-move-desc {
+      font-family: var(--font-family);
+      font-size: var(--font-sm);
+      color: var(--text-secondary);
+      margin: 0;
+      line-height: 1.4;
+    }
+
+    .hs-move-time {
+      flex-shrink: 0;
+      font-family: var(--font-family);
+      font-size: var(--font-xs);
+      color: var(--text-muted);
+      white-space: nowrap;
+    }
+
+    /* Footer */
+    .hs-footer {
+      padding: var(--space-md) var(--space-lg);
+      border-top: 1px solid var(--border-light);
+      flex-shrink: 0;
+    }
+
+    .hs-btn-back {
+      width: 100%;
+      font-family: var(--font-family);
+      font-size: var(--font-base);
+      font-weight: 700;
+      border: none;
+      border-radius: var(--radius-lg);
+      padding: var(--space-sm) var(--space-lg);
+      cursor: pointer;
+      background: var(--pg-slate-700);
+      color: var(--text-primary);
+      transition: transform 0.15s ease, background 0.15s ease;
+      text-align: center;
+    }
+
+    .hs-btn-back:hover {
+      transform: scale(1.02);
+      background: var(--pg-slate-600);
+    }
+
+    .hs-btn-back:active {
+      transform: scale(0.98);
+    }
+
+    @media (max-width: 480px) {
+      .hs-container {
+        max-height: 100vh;
+        border-radius: 0;
+      }
+
+      .hs-header {
+        padding: var(--space-sm) var(--space-md);
+      }
+
+      .hs-stats {
+        padding: var(--space-xs) var(--space-md);
+        gap: var(--space-md);
+      }
+
+      .hs-move-list {
+        padding: var(--space-xs) var(--space-md);
+      }
+
+      .hs-footer {
+        padding: var(--space-sm) var(--space-md);
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+// ---------------------------------------------------------------------------
+// HistoryScreen
+// ---------------------------------------------------------------------------
+
+export class HistoryScreen {
+  private container: HTMLElement | null = null;
+  private onCloseCallback: (() => void) | null = null;
+  private boundKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  show(data: HistoryScreenData, onClose: () => void): void {
+    this.hide();
+    injectStyles();
+
+    this.onCloseCallback = onClose;
+
+    const { moveHistory, gameType, metadata } = data;
+    const formatter = getFormatter(gameType);
+
+    // Build a player-index map from order of first appearance
+    const playerIndexMap = new Map<string, number>();
+    for (const move of moveHistory) {
+      if (!playerIndexMap.has(move.playerId)) {
+        playerIndexMap.set(move.playerId, playerIndexMap.size);
+      }
+    }
+
+    // Root overlay
+    this.container = el("div");
+    this.container.id = CONTAINER_ID;
+
+    const panel = el("div", "hs-container");
+
+    // ── Header ──
+    const header = el("div", "hs-header");
+    const titleGroup = el("div", "hs-title-group");
+    titleGroup.appendChild(el("h2", "hs-title", "Move History"));
+    titleGroup.appendChild(
+      el("span", "hs-game-badge", GAME_LABELS[gameType] ?? gameType),
+    );
+    header.appendChild(titleGroup);
+
+    const closeBtn = el("button", "hs-close", "×");
+    closeBtn.setAttribute("aria-label", "Close history");
+    closeBtn.addEventListener("click", () => this.close());
+    header.appendChild(closeBtn);
+
+    panel.appendChild(header);
+
+    // ── Stats bar ──
+    const meta = (metadata ?? {}) as Record<string, unknown>;
+    const statsBar = el("div", "hs-stats");
+    let hasStats = false;
+
+    const totalMoves = moveHistory.length;
+    if (totalMoves > 0) {
+      statsBar.appendChild(this.buildStat("📊", "Moves", String(totalMoves)));
+      hasStats = true;
+    }
+
+    if (typeof meta.durationSeconds === "number") {
+      statsBar.appendChild(
+        this.buildStat("⏱️", "Duration", formatDuration(meta.durationSeconds as number)),
+      );
+      hasStats = true;
+
+      if (totalMoves > 0) {
+        const avg = Math.round((meta.durationSeconds as number) / totalMoves);
+        statsBar.appendChild(this.buildStat("⚡", "Avg/Move", `${avg}s`));
+      }
+    }
+
+    if (hasStats) {
+      panel.appendChild(statsBar);
+    }
+
+    // ── Move list ──
+    const moveList = el("div", "hs-move-list");
+    moveList.setAttribute("role", "list");
+
+    if (moveHistory.length === 0) {
+      moveList.appendChild(el("p", "hs-empty", "No moves recorded."));
+    } else {
+      for (const move of moveHistory) {
+        const playerIdx = playerIndexMap.get(move.playerId) ?? 0;
+        const entry = el("div", "hs-move-entry");
+        entry.setAttribute("role", "listitem");
+
+        // Turn badge
+        const turnBadge = el(
+          "div",
+          `hs-move-turn hs-player-${Math.min(playerIdx, 3)}`,
+          String(move.turnNumber),
+        );
+        entry.appendChild(turnBadge);
+
+        // Body
+        const body = el("div", "hs-move-body");
+        const playerLabel = el(
+          "p",
+          `hs-move-player hs-player-${Math.min(playerIdx, 3)}`,
+          move.playerName,
+        );
+        body.appendChild(playerLabel);
+
+        const desc = el("p", "hs-move-desc");
+        desc.innerHTML = formatter.formatMove(move);
+        body.appendChild(desc);
+
+        entry.appendChild(body);
+
+        // Timestamp
+        const time = el("span", "hs-move-time", formatTimestamp(move.timestamp));
+        entry.appendChild(time);
+
+        moveList.appendChild(entry);
+      }
+    }
+
+    panel.appendChild(moveList);
+
+    // ── Footer ──
+    const footer = el("div", "hs-footer");
+    const backBtn = el("button", "hs-btn-back", "Back to Results");
+    backBtn.addEventListener("click", () => this.close());
+    footer.appendChild(backBtn);
+    panel.appendChild(footer);
+
+    this.container.appendChild(panel);
+    document.body.appendChild(this.container);
+
+    // Keyboard: Escape to close
+    this.boundKeyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        this.close();
+      }
+    };
+    document.addEventListener("keydown", this.boundKeyHandler);
+
+    // Focus close button for keyboard accessibility
+    closeBtn.focus();
+  }
+
+  hide(): void {
+    if (this.boundKeyHandler) {
+      document.removeEventListener("keydown", this.boundKeyHandler);
+      this.boundKeyHandler = null;
+    }
+    if (this.container?.parentElement) {
+      this.container.parentElement.removeChild(this.container);
+    }
+    this.container = null;
+    this.onCloseCallback = null;
+  }
+
+  destroy(): void {
+    this.hide();
+    const injected = document.getElementById(STYLE_ID);
+    if (injected) {
+      injected.remove();
+    }
+  }
+
+  private close(): void {
+    const cb = this.onCloseCallback;
+    this.hide();
+    cb?.();
+  }
+
+  private buildStat(icon: string, label: string, value: string): HTMLElement {
+    const item = el("div", "hs-stat-item");
+    item.appendChild(el("span", undefined, icon));
+    item.appendChild(el("span", undefined, `${label}:`));
+    item.appendChild(el("span", "hs-stat-value", value));
+    return item;
+  }
+}

--- a/client/src/ui/VictoryScreen.ts
+++ b/client/src/ui/VictoryScreen.ts
@@ -28,7 +28,8 @@ const SCORE_LABELS: Record<string, string> = {
 
 export type VictoryScreenEvent =
   | { type: "play_again"; gameType: string }
-  | { type: "back_to_lobby" };
+  | { type: "back_to_lobby" }
+  | { type: "view_history"; gameType: string };
 
 export interface VictoryPlayerInfo {
   sessionId: string;
@@ -598,13 +599,9 @@ function injectStyles(): void {
       border: 1px solid var(--pg-slate-600);
     }
 
-    .vs-btn-history:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    .vs-btn-history:disabled:hover {
-      transform: none;
+    .vs-btn-history:hover {
+      background: var(--pg-slate-600);
+      color: var(--text-primary);
     }
   `;
   document.head.appendChild(style);
@@ -726,8 +723,9 @@ export class VictoryScreen {
     });
 
     const historyBtn = el("button", "vs-btn vs-btn-history", "View History");
-    historyBtn.disabled = true;
-    historyBtn.title = "Coming soon";
+    historyBtn.addEventListener("click", () => {
+      this.eventCallback?.({ type: "view_history", gameType });
+    });
 
     actions.appendChild(playAgainBtn);
     actions.appendChild(historyBtn);

--- a/client/src/ui/historyFormatters.ts
+++ b/client/src/ui/historyFormatters.ts
@@ -1,0 +1,85 @@
+import type { MoveEntry } from "@eschaton/shared";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MoveFormatter {
+  /** Returns an HTML string describing the move */
+  formatMove(entry: MoveEntry): string;
+  /** Returns an emoji/icon for the move type */
+  getMoveIcon(entry: MoveEntry): string;
+}
+
+// ---------------------------------------------------------------------------
+// Coordinate helpers (checkers)
+// ---------------------------------------------------------------------------
+
+const COL_LETTERS = "ABCDEFGH";
+
+/** Convert a 0-based board index (0-63) to chess-like notation (A1-H8). */
+function indexToNotation(index: number): string {
+  if (typeof index !== "number" || index < 0 || index > 63) return String(index);
+  const row = Math.floor(index / 8) + 1;
+  const col = index % 8;
+  return `${COL_LETTERS[col]}${row}`;
+}
+
+// ---------------------------------------------------------------------------
+// Checkers formatter
+// ---------------------------------------------------------------------------
+
+const checkersFormatter: MoveFormatter = {
+  formatMove(entry: MoveEntry): string {
+    const p = entry.payload;
+    const from = typeof p.from === "number" ? indexToNotation(p.from) : String(p.from ?? "?");
+    const to = typeof p.to === "number" ? indexToNotation(p.to) : String(p.to ?? "?");
+
+    if (entry.actionType === "king" || p.kinged === true) {
+      return `👑 Kinged at ${to}`;
+    }
+
+    if (entry.actionType === "capture" || p.captured != null) {
+      return `⚔️ ${from} → ${to} (capture)`;
+    }
+
+    if (entry.actionType === "move") {
+      return `➡️ ${from} → ${to}`;
+    }
+
+    return entry.description ?? `Move ${entry.actionType}`;
+  },
+
+  getMoveIcon(entry: MoveEntry): string {
+    if (entry.actionType === "king" || entry.payload.kinged === true) return "👑";
+    if (entry.actionType === "capture" || entry.payload.captured != null) return "⚔️";
+    return "➡️";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Default (fallback) formatter
+// ---------------------------------------------------------------------------
+
+const defaultFormatter: MoveFormatter = {
+  formatMove(entry: MoveEntry): string {
+    return entry.description ?? `Move: ${entry.actionType}`;
+  },
+
+  getMoveIcon(_entry: MoveEntry): string {
+    return "🔹";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const formatters: Record<string, MoveFormatter> = {
+  checkers: checkersFormatter,
+};
+
+/** Get the MoveFormatter for a given game type, falling back to a generic one. */
+export function getFormatter(gameType: string): MoveFormatter {
+  return formatters[gameType] ?? defaultFormatter;
+}

--- a/server/src/__tests__/move-history.test.ts
+++ b/server/src/__tests__/move-history.test.ts
@@ -1,0 +1,605 @@
+import { BaseGameState, type GamePlugin, type MoveEntry } from "../../../shared/src/index.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockedCloseCode, mockGameRegistry } = vi.hoisted(() => ({
+  mockedCloseCode: {
+    NORMAL_CLOSURE: 1000,
+    CONSENTED: 4000,
+  },
+  mockGameRegistry: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("colyseus", () => ({
+  Room: class {},
+  CloseCode: mockedCloseCode,
+}));
+
+vi.mock("../game/GameRegistry", () => ({ gameRegistry: mockGameRegistry }));
+vi.mock("@eschaton/shared", async () => await import("../../../shared/src/index.ts"));
+
+const roomModule = await import("../game/BaseGameRoom")
+  .catch(() => import("../game/BaseGameRoom.ts"))
+  .catch(() => import("../game/BaseGameRoom.js"))
+  .catch(() => null);
+
+const BaseGameRoom = roomModule?.BaseGameRoom;
+const describeRoom = BaseGameRoom ? describe : describe.skip;
+
+type MockClient = {
+  sessionId: string;
+  send: ReturnType<typeof vi.fn>;
+};
+
+type TestRoom = Record<string, any> & {
+  messageHandlers: Map<string, (client: MockClient, payload: unknown) => unknown>;
+};
+
+class TestState extends BaseGameState {}
+
+const GAME_END_MESSAGE = "game-end";
+
+function createClient(sessionId: string): MockClient {
+  return {
+    sessionId,
+    send: vi.fn(),
+  };
+}
+
+function createPlugin(overrides: Partial<GamePlugin<TestState>> = {}): GamePlugin<TestState> {
+  const stateFactory = overrides.createState ?? (() => new TestState());
+  const lifecycle = {
+    onCreate: vi.fn(),
+    onPlayerJoin: vi.fn(),
+    onGameStart: vi.fn(),
+    onPlayerLeave: vi.fn(),
+    onPlayerReconnect: vi.fn(),
+    onGameEnd: vi.fn(),
+    onTick: undefined,
+    ...overrides.lifecycle,
+  };
+  const validateAction = vi.fn().mockReturnValue(true);
+  const checkGameEnd = vi.fn().mockReturnValue(null);
+  const actions = {
+    move: vi.fn().mockReturnValue({ success: true, endsTurn: true }),
+    ...overrides.actions,
+  };
+
+  const plugin: GamePlugin<TestState> = {
+    id: "checkers",
+    name: "Checkers",
+    metadata: {
+      playerCount: [2, 4],
+      estimatedDuration: 20,
+      complexity: 2,
+      description: "Test plugin",
+      hasHiddenInformation: false,
+      ...overrides.metadata,
+    },
+    createState: stateFactory,
+    lifecycle,
+    turnConfig: {
+      mode: "sequential",
+      turnOrder: { type: "round-robin" },
+      allowPass: false,
+      ...overrides.turnConfig,
+    },
+    actions,
+    conditions: {
+      validateAction,
+      checkGameEnd,
+      ...overrides.conditions,
+    },
+  };
+
+  if (overrides.formatMoveHistory) {
+    plugin.formatMoveHistory = overrides.formatMoveHistory;
+  }
+
+  return plugin;
+}
+
+function createRoom(): TestRoom {
+  if (!BaseGameRoom) {
+    throw new Error("BaseGameRoom is not available in the template yet");
+  }
+
+  const messageHandlers = new Map<string, (client: MockClient, payload: unknown) => unknown>();
+
+  return Object.assign(new BaseGameRoom(), {
+    roomId: "test-room",
+    clients: [] as MockClient[],
+    maxClients: 1,
+    messageHandlers,
+    allowReconnection: vi.fn(),
+    broadcast: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    presence: { publish: vi.fn() },
+    onMessage: vi.fn((type: string, handler: (client: MockClient, payload: unknown) => unknown) => {
+      messageHandlers.set(type, handler);
+    }),
+    setSimulationInterval: vi.fn(),
+    setState: vi.fn(function setState(state: TestState) {
+      this.state = state;
+    }),
+  });
+}
+
+function setupTwoPlayerGame(pluginOverrides: Partial<GamePlugin<TestState>> = {}) {
+  const room = createRoom();
+  const plugin = createPlugin(pluginOverrides);
+  mockGameRegistry.get.mockReturnValue(plugin);
+  room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+  const player1 = createClient("player-1");
+  const player2 = createClient("player-2");
+  room.clients.push(player1, player2);
+  room.onJoin(player1, { displayName: "Alice" });
+  room.onJoin(player2, { displayName: "Bob" });
+
+  return { room, plugin, player1, player2 };
+}
+
+function getGameEndBroadcast(room: TestRoom): Record<string, unknown> | undefined {
+  const calls = room.broadcast.mock.calls as unknown[][];
+  const call = calls.find((c) => c[0] === GAME_END_MESSAGE);
+  return call ? (call[1] as Record<string, unknown>) : undefined;
+}
+
+describeRoom("Move History — P6.1 Core Infrastructure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("MoveEntry interface validation", () => {
+    it("validates a correct MoveEntry object structure", () => {
+      const validEntry: MoveEntry = {
+        turnNumber: 1,
+        playerId: "player-1",
+        playerName: "Alice",
+        actionType: "move",
+        payload: { from: 10, to: 15 },
+        timestamp: Date.now(),
+      };
+
+      expect(validEntry.turnNumber).toBeTypeOf("number");
+      expect(validEntry.playerId).toBeTypeOf("string");
+      expect(validEntry.playerName).toBeTypeOf("string");
+      expect(validEntry.actionType).toBeTypeOf("string");
+      expect(validEntry.payload).toBeTypeOf("object");
+      expect(validEntry.timestamp).toBeTypeOf("number");
+    });
+
+    it("validates MoveEntry with optional description field", () => {
+      const entryWithDescription: MoveEntry = {
+        turnNumber: 2,
+        playerId: "player-2",
+        playerName: "Bob",
+        actionType: "capture",
+        payload: { from: 20, to: 29 },
+        timestamp: Date.now(),
+        description: "Black captures red piece",
+      };
+
+      expect(entryWithDescription.description).toBeTypeOf("string");
+      expect(entryWithDescription.description).toBe("Black captures red piece");
+    });
+
+    it("can be imported from @eschaton/shared", async () => {
+      const sharedModule = await import("../../../shared/src/index.ts");
+      expect(sharedModule).toBeDefined();
+    });
+  });
+
+  describe("Move recording in game flow", () => {
+    it("records moves in the moveHistory array during gameplay", async () => {
+      const { room, player1, player2 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      expect(room.moveHistory).toHaveLength(1);
+      expect(room.moveHistory[0]).toMatchObject({
+        turnNumber: 1,
+        playerId: "player-1",
+        actionType: "move",
+        payload: { from: 17, to: 24 },
+      });
+
+      await room.messageHandlers.get("move")?.(player2, { from: 40, to: 33 });
+
+      expect(room.moveHistory).toHaveLength(2);
+      expect(room.moveHistory[1]).toMatchObject({
+        turnNumber: 2,
+        playerId: "player-2",
+        actionType: "move",
+      });
+    });
+
+    it("records moves with correct field types and values", async () => {
+      const { room, player1 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      const entry = room.moveHistory[0] as MoveEntry;
+      expect(entry.turnNumber).toBe(1);
+      expect(entry.playerId).toBe("player-1");
+      expect(entry.playerName).toBe("Alice");
+      expect(entry.actionType).toBe("move");
+      expect(entry.payload).toEqual({ from: 17, to: 24 });
+      expect(entry.timestamp).toBeGreaterThanOrEqual(0);
+      expect(typeof entry.timestamp).toBe("number");
+    });
+
+    it("maintains monotonically increasing timestamps", async () => {
+      const { room, player1, player2 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+      await room.messageHandlers.get("move")?.(player2, { from: 40, to: 33 });
+      await room.messageHandlers.get("move")?.(player1, { from: 19, to: 26 });
+
+      const timestamps = room.moveHistory.map((entry: MoveEntry) => entry.timestamp);
+      for (let i = 1; i < timestamps.length; i += 1) {
+        expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+      }
+    });
+
+    it("records multi-jump moves as separate entries", async () => {
+      const moveHandler = vi.fn()
+        .mockReturnValueOnce({ success: true, endsTurn: false })
+        .mockReturnValueOnce({ success: true, endsTurn: true });
+
+      const { room, player1 } = setupTwoPlayerGame({
+        actions: { move: moveHandler },
+      });
+
+      // First jump — does not end turn
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 26 });
+      expect(room.moveHistory).toHaveLength(1);
+
+      // Second jump — ends turn
+      await room.messageHandlers.get("move")?.(player1, { from: 26, to: 35 });
+      expect(room.moveHistory).toHaveLength(2);
+
+      // Both entries share the same turnNumber (same turn)
+      expect(room.moveHistory[0].turnNumber).toBe(1);
+      expect(room.moveHistory[1].turnNumber).toBe(1);
+      expect(room.moveHistory[0].playerId).toBe("player-1");
+      expect(room.moveHistory[1].playerId).toBe("player-1");
+    });
+
+    it("includes player display name in move entries", async () => {
+      const { room, player1 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      expect(room.moveHistory[0].playerName).toBe("Alice");
+    });
+  });
+
+  describe("History delivery in GameResult", () => {
+    it("includes moveHistory in GameResult metadata", async () => {
+      const { room, player1 } = setupTwoPlayerGame({
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd: vi.fn().mockReturnValue({
+            type: "win",
+            winnerId: "player-1",
+            scores: { "player-1": 1 },
+          }),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 26 });
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      expect(result).toBeDefined();
+      expect(result.metadata.moveHistory).toBeDefined();
+      expect(Array.isArray(result.metadata.moveHistory)).toBe(true);
+      expect(result.metadata.moveHistory).toHaveLength(1);
+    });
+
+    it("includes totalMoves count in GameResult metadata", async () => {
+      const { room, player1 } = setupTwoPlayerGame({
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd: vi.fn().mockReturnValue({
+            type: "win",
+            winnerId: "player-1",
+            scores: { "player-1": 1 },
+          }),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 26 });
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      expect(result.metadata.totalMoves).toBe(1);
+    });
+
+    it("delivers complete move history at game end", async () => {
+      const checkGameEnd = vi.fn()
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(null)
+        .mockReturnValue({
+          type: "win",
+          winnerId: "player-1",
+          scores: { "player-1": 1 },
+        });
+
+      const { room, player1, player2 } = setupTwoPlayerGame({
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd,
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 1, to: 2 });
+      await room.messageHandlers.get("move")?.(player2, { from: 3, to: 4 });
+      await room.messageHandlers.get("move")?.(player1, { from: 5, to: 6 });
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      const history = result.metadata.moveHistory as MoveEntry[];
+      expect(history).toHaveLength(3);
+      expect(history[0].actionType).toBe("move");
+      expect(history[0].playerId).toBe("player-1");
+      expect(history[1].playerId).toBe("player-2");
+      expect(history[2].playerId).toBe("player-1");
+    });
+  });
+
+  describe("History reset on new game", () => {
+    it("clears move history when game starts", () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      // Inject leftover history from a hypothetical previous game
+      room.moveHistory = [
+        {
+          turnNumber: 1,
+          playerId: "player-1",
+          playerName: "Alice",
+          actionType: "move",
+          payload: {},
+          timestamp: Date.now(),
+        },
+      ];
+
+      // Joining enough players triggers startGame, which resets moveHistory
+      const p1 = createClient("player-1");
+      const p2 = createClient("player-2");
+      room.clients.push(p1, p2);
+      room.onJoin(p1);
+      room.onJoin(p2);
+
+      expect(room.moveHistory).toEqual([]);
+    });
+
+    it("starts with empty history array on room creation", () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      expect(room.moveHistory).toEqual([]);
+      expect(room.moveHistory).toHaveLength(0);
+    });
+  });
+
+  describe("Plugin formatMoveHistory integration", () => {
+    it("calls plugin formatMoveHistory before attaching to GameResult", async () => {
+      const formatFn = vi.fn((_state: TestState, moves: MoveEntry[]) => moves);
+
+      const { room, player1 } = setupTwoPlayerGame({
+        formatMoveHistory: formatFn,
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd: vi.fn().mockReturnValue({
+            type: "win",
+            winnerId: "player-1",
+            scores: { "player-1": 1 },
+          }),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      expect(formatFn).toHaveBeenCalled();
+    });
+
+    it("uses formatted history in GameResult when plugin provides formatter", async () => {
+      const formatFn = (_state: TestState, moves: MoveEntry[]) =>
+        moves.map((move) => ({
+          ...move,
+          description: `Move from ${(move.payload as Record<string, number>).from} to ${(move.payload as Record<string, number>).to}`,
+        }));
+
+      const { room, player1 } = setupTwoPlayerGame({
+        formatMoveHistory: formatFn,
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd: vi.fn().mockReturnValue({
+            type: "win",
+            winnerId: "player-1",
+            scores: { "player-1": 1 },
+          }),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      const history = result.metadata.moveHistory as MoveEntry[];
+      expect(history[0].description).toContain("Move from");
+    });
+
+    it("uses raw history when plugin does not provide formatter", async () => {
+      const { room, player1 } = setupTwoPlayerGame({
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(true),
+          checkGameEnd: vi.fn().mockReturnValue({
+            type: "win",
+            winnerId: "player-1",
+            scores: { "player-1": 1 },
+          }),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      const history = result.metadata.moveHistory as MoveEntry[];
+      expect(history[0].description).toBeUndefined();
+    });
+
+    it("handles formatter that adds move descriptions", () => {
+      const rawMoves: MoveEntry[] = [
+        {
+          turnNumber: 1,
+          playerId: "player-1",
+          playerName: "Player 1",
+          actionType: "move",
+          payload: { from: 10, to: 15 },
+          timestamp: Date.now(),
+        },
+      ];
+
+      const formattedMoves = rawMoves.map((move) => ({
+        ...move,
+        description: `${move.playerName} moved from ${move.payload.from} to ${move.payload.to}`,
+      }));
+
+      expect(formattedMoves[0].description).toBe("Player 1 moved from 10 to 15");
+    });
+  });
+
+  describe("CPU move recording", () => {
+    it("records CPU opponent moves in history", async () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      const humanPlayer = createClient("player-1");
+      const cpuClient = createClient("cpu-opponent");
+      room.clients.push(humanPlayer, cpuClient);
+      room.onJoin(humanPlayer, { displayName: "Alice" });
+      room.onJoin(cpuClient, { displayName: "CPU Opponent" });
+
+      await room.messageHandlers.get("move")?.(humanPlayer, { from: 17, to: 24 });
+      await room.messageHandlers.get("move")?.(cpuClient, { from: 40, to: 33 });
+
+      expect(room.moveHistory).toHaveLength(2);
+      expect(room.moveHistory[1].playerId).toBe("cpu-opponent");
+      expect(room.moveHistory[1].playerName).toBe("CPU Opponent");
+    });
+
+    it("distinguishes CPU moves from human player moves", async () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      const humanPlayer = createClient("player-1");
+      const cpuClient = createClient("cpu-opponent");
+      room.clients.push(humanPlayer, cpuClient);
+      room.onJoin(humanPlayer, { displayName: "Alice" });
+      room.onJoin(cpuClient, { displayName: "CPU Opponent" });
+
+      await room.messageHandlers.get("move")?.(humanPlayer, { from: 17, to: 24 });
+      await room.messageHandlers.get("move")?.(cpuClient, { from: 40, to: 33 });
+
+      const humanMove = room.moveHistory[0] as MoveEntry;
+      const cpuMove = room.moveHistory[1] as MoveEntry;
+
+      expect(humanMove.playerId).not.toBe(cpuMove.playerId);
+      expect(cpuMove.playerId).toBe("cpu-opponent");
+    });
+  });
+
+  describe("Edge cases and validation", () => {
+    it("handles empty move history gracefully", async () => {
+      const { room, player2 } = setupTwoPlayerGame({
+        lifecycle: {
+          onCreate: vi.fn(),
+          onGameStart: vi.fn(),
+          onPlayerLeave: vi.fn(),
+          onGameEnd: vi.fn(),
+        },
+      });
+
+      // End the game without any moves via a consented leave
+      await room.onLeave(player2, mockedCloseCode.CONSENTED);
+
+      const result = getGameEndBroadcast(room) as Record<string, Record<string, unknown>>;
+      expect(result).toBeDefined();
+      expect(result.metadata.moveHistory).toEqual([]);
+    });
+
+    it("preserves payload immutability in move history", async () => {
+      const { room, player1, player2 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+      await room.messageHandlers.get("move")?.(player2, { from: 40, to: 33 });
+
+      // Each entry preserves its own payload correctly
+      expect(room.moveHistory[0].payload).toEqual({ from: 17, to: 24 });
+      expect(room.moveHistory[1].payload).toEqual({ from: 40, to: 33 });
+    });
+
+    it("handles concurrent action attempts correctly", async () => {
+      // Colyseus serializes actions so concurrent attempts are processed sequentially
+      const { room, player1, player2 } = setupTwoPlayerGame();
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 24 });
+      await room.messageHandlers.get("move")?.(player2, { from: 40, to: 33 });
+
+      expect(room.moveHistory).toHaveLength(2);
+      expect(room.moveHistory[0].playerId).toBe("player-1");
+      expect(room.moveHistory[1].playerId).toBe("player-2");
+    });
+
+    it("handles invalid moves without recording them", async () => {
+      const { room, player1 } = setupTwoPlayerGame({
+        conditions: {
+          validateAction: vi.fn().mockReturnValue(false),
+          checkGameEnd: vi.fn().mockReturnValue(null),
+        },
+      });
+
+      await room.messageHandlers.get("move")?.(player1, { from: 17, to: 10 });
+
+      expect(room.moveHistory).toHaveLength(0);
+    });
+  });
+
+  describe("getGameElapsedTime helper", () => {
+    it("returns elapsed time in milliseconds", () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      room.gameStartTime = Date.now() - 5000;
+
+      const elapsed = room.getGameElapsedTime();
+      expect(elapsed).toBeGreaterThanOrEqual(5000);
+      expect(elapsed).toBeLessThan(6000);
+    });
+
+    it("returns 0 when game has not started", () => {
+      const room = createRoom();
+      const plugin = createPlugin();
+      mockGameRegistry.get.mockReturnValue(plugin);
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
+
+      expect(room.getGameElapsedTime()).toBe(0);
+    });
+  });
+});

--- a/server/src/game/BaseGameRoom.ts
+++ b/server/src/game/BaseGameRoom.ts
@@ -9,6 +9,7 @@ import {
   type GameOptions,
   type GamePlugin,
   type GameResult,
+  type MoveEntry,
 } from "@eschaton/shared";
 import * as gameRepository from "../db/gameRepository.js";
 import { getPool } from "../db.js";
@@ -53,6 +54,7 @@ export class BaseGameRoom extends Room {
   private cpuOpponentEnabled = false;
   private pendingCpuTurn?: Delayed;
   private headToHeadMode = false;
+  private moveHistory: MoveEntry[] = [];
 
   override async onCreate(options: BaseGameRoomOptions = {}) {
     const gameType = typeof options.gameType === "string" ? options.gameType.trim() : "";
@@ -348,6 +350,8 @@ export class BaseGameRoom extends Room {
       return false;
     }
 
+    this.recordMove(actionType, actingClient.sessionId, payload);
+
     this.broadcastPlayerMessages();
 
     const gameResult = this.plugin.conditions.checkGameEnd(this.state);
@@ -378,6 +382,7 @@ export class BaseGameRoom extends Room {
 
     this.state.phase = "playing";
     this.gameStartTime = Date.now();
+    this.moveHistory = [];
     this.turnManager = new TurnManager(this.orderTurnPlayers(playerIds), {
       turnTimeLimit: this.plugin.turnConfig.turnTimeLimit,
       onTimeout: (sessionId) => {
@@ -477,10 +482,16 @@ export class BaseGameRoom extends Room {
     const durationSeconds = this.gameStartTime
       ? Math.floor((Date.now() - this.gameStartTime) / 1000)
       : 0;
+
+    const formattedHistory = this.plugin.formatMoveHistory
+      ? this.plugin.formatMoveHistory(this.state, this.moveHistory)
+      : this.moveHistory;
+
     result.metadata = {
       ...result.metadata,
       durationSeconds,
       totalMoves: this.state.turnNumber ?? 0,
+      moveHistory: formattedHistory,
     };
 
     this.plugin.lifecycle.onGameEnd?.(this.state, result);
@@ -702,6 +713,24 @@ export class BaseGameRoom extends Room {
       sessionId,
       send: () => undefined,
     } as unknown as Client;
+  }
+
+  private recordMove(actionType: string, sessionId: string, payload: unknown) {
+    const player = this.state.players.get(sessionId);
+    const playerName = player?.displayName ?? "Unknown";
+
+    this.moveHistory.push({
+      turnNumber: this.state.turnNumber ?? 0,
+      playerId: sessionId,
+      playerName,
+      actionType,
+      payload: payload as Record<string, unknown>,
+      timestamp: this.getGameElapsedTime(),
+    });
+  }
+
+  private getGameElapsedTime(): number {
+    return this.gameStartTime ? Date.now() - this.gameStartTime : 0;
   }
 
   private getParticipatingPlayers() {

--- a/server/src/games/checkers/CheckersPlugin.ts
+++ b/server/src/games/checkers/CheckersPlugin.ts
@@ -9,6 +9,7 @@ import {
   type ActionResult,
   type GamePlugin,
   type GameResult,
+  type MoveEntry,
 } from "@eschaton/shared";
 import {
   applyMove,
@@ -64,6 +65,125 @@ function getCurrentPlayerColor(state: CheckersState): CheckersColor | null {
   }
 
   return getPlayerColor(currentPlayer.playerIndex);
+}
+
+const BOARD_WIDTH = 8;
+const COLUMN_LETTERS = "ABCDEFGH";
+
+function indexToNotation(index: number): string {
+  const col = index % BOARD_WIDTH;
+  const row = Math.floor(index / BOARD_WIDTH) + 1;
+  return `${COLUMN_LETTERS[col]}${row}`;
+}
+
+function isCapture(from: number, to: number): boolean {
+  const rowDelta = Math.abs(
+    Math.floor(to / BOARD_WIDTH) - Math.floor(from / BOARD_WIDTH),
+  );
+  return rowDelta === 2;
+}
+
+function isKingPromotion(playerIndex: number, to: number): boolean {
+  const row = Math.floor(to / BOARD_WIDTH);
+  // Player 0 = BLACK moves toward row 7, Player 1 = RED moves toward row 0
+  if (playerIndex === 0) return row === BOARD_WIDTH - 1;
+  if (playerIndex === 1) return row === 0;
+  return false;
+}
+
+function getPlayerIndexBySessionId(
+  state: CheckersState,
+  sessionId: string,
+): number | null {
+  const player = state.players.get(sessionId);
+  if (!player) return null;
+  return player.playerIndex;
+}
+
+function formatMoveEntries(
+  state: CheckersState,
+  moves: MoveEntry[],
+): MoveEntry[] {
+  const formatted: MoveEntry[] = [];
+
+  for (let i = 0; i < moves.length; i++) {
+    const move = moves[i];
+    const from = move.payload.from as number | undefined;
+    const to = move.payload.to as number | undefined;
+
+    if (typeof from !== "number" || typeof to !== "number") {
+      formatted.push({ ...move });
+      continue;
+    }
+
+    const playerIndex = getPlayerIndexBySessionId(state, move.playerId);
+    const name = move.playerName;
+    const fromNotation = indexToNotation(from);
+    const toNotation = indexToNotation(to);
+
+    // Detect multi-jump: consecutive captures by same player where prev.to === current.from
+    const prevFormatted = formatted[formatted.length - 1];
+    const isMultiJump =
+      prevFormatted &&
+      prevFormatted.playerId === move.playerId &&
+      isCapture(from, to) &&
+      isCapture(
+        prevFormatted.payload.from as number,
+        prevFormatted.payload.to as number,
+      ) &&
+      (prevFormatted.payload.to as number) === from;
+
+    if (isMultiJump && prevFormatted) {
+      // Count total captures in this chain
+      let chainStart = formatted.length - 1;
+      while (chainStart > 0) {
+        const prev = formatted[chainStart - 1];
+        if (
+          prev.playerId !== move.playerId ||
+          !isCapture(prev.payload.from as number, prev.payload.to as number) ||
+          (prev.payload.to as number) !==
+            (formatted[chainStart].payload.from as number)
+        ) {
+          break;
+        }
+        chainStart--;
+      }
+      const captureCount = formatted.length - chainStart + 1;
+      const description = `${name} captured ${captureCount} pieces`;
+
+      // Update all entries in the chain with the running count
+      for (let j = chainStart; j < formatted.length; j++) {
+        formatted[j] = { ...formatted[j], description };
+      }
+      formatted.push({ ...move, description });
+    } else if (
+      playerIndex !== null &&
+      isCapture(from, to) &&
+      isKingPromotion(playerIndex, to)
+    ) {
+      formatted.push({
+        ...move,
+        description: `${name} captured at ${toNotation} (from ${fromNotation}), kinged at ${toNotation}`,
+      });
+    } else if (playerIndex !== null && isKingPromotion(playerIndex, to)) {
+      formatted.push({
+        ...move,
+        description: `${name} kinged at ${toNotation}`,
+      });
+    } else if (isCapture(from, to)) {
+      formatted.push({
+        ...move,
+        description: `${name} captured at ${toNotation} (from ${fromNotation})`,
+      });
+    } else {
+      formatted.push({
+        ...move,
+        description: `${name} moved from ${fromNotation} to ${toNotation}`,
+      });
+    }
+  }
+
+  return formatted;
 }
 
 function countPlayerPieces(state: CheckersState, color: CheckersColor) {
@@ -247,5 +367,8 @@ export const checkersPlugin: GamePlugin<CheckersState> = {
 
       return validateMove(state, client.sessionId, payload);
     },
+  },
+  formatMoveHistory(state, moves) {
+    return formatMoveEntries(state, moves);
   },
 };

--- a/server/src/games/checkers/__tests__/formatMoveHistory.test.ts
+++ b/server/src/games/checkers/__tests__/formatMoveHistory.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MoveEntry } from "@eschaton/shared";
+
+vi.mock("@eschaton/shared", async () => await import("../../../../../shared/src/index.ts"));
+
+const shared = await import("../../../../../shared/src/index.ts");
+const { BLACK, CheckersState, EMPTY, RED } = shared;
+const { checkersPlugin } = await import("../CheckersPlugin");
+
+const BOARD_WIDTH = 8;
+
+function toIndex(row: number, col: number): number {
+  return row * BOARD_WIDTH + col;
+}
+
+function createGameState() {
+  const state = checkersPlugin.createState();
+  checkersPlugin.lifecycle.onPlayerJoin?.(
+    state,
+    { sessionId: "player-1" } as never,
+    0,
+  );
+  checkersPlugin.lifecycle.onPlayerJoin?.(
+    state,
+    { sessionId: "player-2" } as never,
+    1,
+  );
+  const p1 = state.players.get("player-1")!;
+  p1.displayName = "Alice";
+  const p2 = state.players.get("player-2")!;
+  p2.displayName = "Bob";
+  return state;
+}
+
+function makeMoveEntry(
+  overrides: Partial<MoveEntry> & { payload: Record<string, unknown> },
+): MoveEntry {
+  return {
+    turnNumber: 1,
+    playerId: "player-1",
+    playerName: "Alice",
+    actionType: "move",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+describe("CheckersPlugin.formatMoveHistory", () => {
+  it("exists on the plugin", () => {
+    expect(checkersPlugin.formatMoveHistory).toBeDefined();
+    expect(typeof checkersPlugin.formatMoveHistory).toBe("function");
+  });
+
+  it("returns empty array for empty history", () => {
+    const state = createGameState();
+    const result = checkersPlugin.formatMoveHistory!(state, []);
+    expect(result).toEqual([]);
+  });
+
+  it("formats a regular move with coordinate notation", () => {
+    const state = createGameState();
+    // from=0 (A1), to=9 (B2)
+    const moves: MoveEntry[] = [
+      makeMoveEntry({ payload: { from: 0, to: 9 } }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Alice moved from A1 to B2");
+  });
+
+  it("formats a capture move (row delta = 2)", () => {
+    const state = createGameState();
+    // from=toIndex(2,1)=17 (B3), to=toIndex(4,3)=35 (D5) — jumps 2 rows
+    const from = toIndex(2, 1);
+    const to = toIndex(4, 3);
+    const moves: MoveEntry[] = [makeMoveEntry({ payload: { from, to } })];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Alice captured at D5 (from B3)");
+  });
+
+  it("formats king promotion for BLACK reaching row 7", () => {
+    const state = createGameState();
+    // BLACK (player-1, playerIndex=0) moves to row 7
+    const from = toIndex(6, 2);
+    const to = toIndex(7, 3);
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        playerId: "player-1",
+        playerName: "Alice",
+        payload: { from, to },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Alice kinged at D8");
+  });
+
+  it("formats king promotion for RED reaching row 0", () => {
+    const state = createGameState();
+    // RED (player-2, playerIndex=1) moves to row 0
+    const from = toIndex(1, 2);
+    const to = toIndex(0, 3);
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        playerId: "player-2",
+        playerName: "Bob",
+        payload: { from, to },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Bob kinged at D1");
+  });
+
+  it("formats a capture that also promotes to king", () => {
+    const state = createGameState();
+    // BLACK captures and lands on row 7
+    const from = toIndex(5, 4);
+    const to = toIndex(7, 6);
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        playerId: "player-1",
+        playerName: "Alice",
+        payload: { from, to },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe(
+      "Alice captured at G8 (from E6), kinged at G8",
+    );
+  });
+
+  it("formats multi-jump captures with piece count", () => {
+    const state = createGameState();
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        turnNumber: 1,
+        payload: { from: toIndex(2, 1), to: toIndex(4, 3) },
+      }),
+      makeMoveEntry({
+        turnNumber: 1,
+        payload: { from: toIndex(4, 3), to: toIndex(6, 5) },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Alice captured 2 pieces");
+    expect(result[1].description).toBe("Alice captured 2 pieces");
+  });
+
+  it("formats a triple-jump with correct count", () => {
+    const state = createGameState();
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        turnNumber: 1,
+        payload: { from: toIndex(0, 1), to: toIndex(2, 3) },
+      }),
+      makeMoveEntry({
+        turnNumber: 1,
+        payload: { from: toIndex(2, 3), to: toIndex(4, 5) },
+      }),
+      makeMoveEntry({
+        turnNumber: 1,
+        payload: { from: toIndex(4, 5), to: toIndex(6, 7) },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].description).toBe("Alice captured 3 pieces");
+    expect(result[1].description).toBe("Alice captured 3 pieces");
+    expect(result[2].description).toBe("Alice captured 3 pieces");
+  });
+
+  it("handles moves with missing payload fields gracefully", () => {
+    const state = createGameState();
+    const moves: MoveEntry[] = [
+      makeMoveEntry({ payload: {} }),
+      makeMoveEntry({ payload: { from: 0 } }),
+      makeMoveEntry({ payload: { to: 9 } }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result).toHaveLength(3);
+    expect(result[0].description).toBeUndefined();
+    expect(result[1].description).toBeUndefined();
+    expect(result[2].description).toBeUndefined();
+  });
+
+  it("preserves original MoveEntry fields", () => {
+    const state = createGameState();
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        turnNumber: 5,
+        playerId: "player-2",
+        playerName: "Bob",
+        actionType: "move",
+        timestamp: 12345,
+        payload: { from: 0, to: 9 },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    expect(result[0].turnNumber).toBe(5);
+    expect(result[0].playerId).toBe("player-2");
+    expect(result[0].playerName).toBe("Bob");
+    expect(result[0].actionType).toBe("move");
+    expect(result[0].timestamp).toBe(12345);
+    expect(result[0].payload).toEqual({ from: 0, to: 9 });
+  });
+
+  it("does not mutate the original moves array", () => {
+    const state = createGameState();
+    const original: MoveEntry[] = [
+      makeMoveEntry({ payload: { from: 0, to: 9 } }),
+    ];
+    const originalCopy = JSON.parse(JSON.stringify(original));
+    checkersPlugin.formatMoveHistory!(state, original);
+    expect(original).toEqual(originalCopy);
+  });
+
+  it("handles unknown player gracefully (no king detection)", () => {
+    const state = createGameState();
+    // Player ID not in state — move to row 7 should not crash
+    const moves: MoveEntry[] = [
+      makeMoveEntry({
+        playerId: "unknown-player",
+        playerName: "Ghost",
+        payload: { from: toIndex(6, 0), to: toIndex(7, 1) },
+      }),
+    ];
+    const result = checkersPlugin.formatMoveHistory!(state, moves);
+    // Can't determine king promotion without playerIndex, so regular move
+    expect(result[0].description).toBe("Ghost moved from A7 to B8");
+  });
+
+  it("correctly converts board corners to notation", () => {
+    const state = createGameState();
+    const corners = [
+      { from: 0, to: 9, expected: "A1 to B2" },
+      { from: 7, to: 14, expected: "H1 to G2" },
+    ];
+    for (const { from, to, expected } of corners) {
+      const result = checkersPlugin.formatMoveHistory!(state, [
+        makeMoveEntry({ payload: { from, to } }),
+      ]);
+      expect(result[0].description).toContain(expected);
+    }
+  });
+});

--- a/server/src/games/dominos/__tests__/dominosLogic.test.ts
+++ b/server/src/games/dominos/__tests__/dominosLogic.test.ts
@@ -358,6 +358,48 @@ describe("dominosLogic", () => {
 
       expect(state.board.length).toBe(3);
     });
+
+    it("sets exposedEnd correctly when highPips matches the chain end", () => {
+      const state = createState();
+      // First tile: 5|3 → openEndA=3, openEndB=5
+      placeTileOnBoard(state, tile(0, 5, 3), "a");
+      
+      // Play 4|5 on end B (where openEndB=5)
+      // Since highPips=5 matches the chain, lowPips=4 becomes the new exposed end
+      placeTileOnBoard(state, tile(1, 5, 4), "b");
+      
+      const lastTile = state.board[state.board.length - 1];
+      expect(lastTile.exposedEnd).toBe(4); // lowPips is exposed
+      expect(state.openEndB).toBe(4);
+    });
+
+    it("sets exposedEnd correctly when lowPips matches the chain end", () => {
+      const state = createState();
+      // First tile: 5|3 → openEndA=3, openEndB=5
+      placeTileOnBoard(state, tile(0, 5, 3), "a");
+      
+      // Play 4|3 on end A (where openEndA=3)
+      // Since lowPips=3 matches the chain, highPips=4 becomes the new exposed end
+      placeTileOnBoard(state, tile(1, 4, 3), "a");
+      
+      const lastTile = state.board[state.board.length - 1];
+      expect(lastTile.exposedEnd).toBe(4); // highPips is exposed
+      expect(state.openEndA).toBe(4);
+    });
+
+    it("sets exposedEnd correctly for a double tile", () => {
+      const state = createState();
+      // First tile: 5|3 → openEndA=3, openEndB=5
+      placeTileOnBoard(state, tile(0, 5, 3), "a");
+      
+      // Play 3|3 on end A (where openEndA=3)
+      // Double matches with highPips, exposedEnd becomes lowPips=3 (same value)
+      placeTileOnBoard(state, tile(1, 3, 3), "a");
+      
+      const lastTile = state.board[state.board.length - 1];
+      expect(lastTile.exposedEnd).toBe(3); // double, so both sides are 3
+      expect(state.openEndA).toBe(3);
+    });
   });
 
   // ── 5. Drawing from boneyard ────────────────────────────────────────

--- a/shared/src/MoveEntry.ts
+++ b/shared/src/MoveEntry.ts
@@ -1,0 +1,20 @@
+/**
+ * Generic move entry for recording game action history.
+ * Used across all game types to maintain a consistent move history format.
+ */
+export interface MoveEntry {
+  /** Turn number when move occurred */
+  turnNumber: number;
+  /** Session ID of player who made the move */
+  playerId: string;
+  /** Player display name */
+  playerName: string;
+  /** Game-specific action type (e.g., "move", "attack", "reinforce") */
+  actionType: string;
+  /** Game-specific payload (move details) */
+  payload: Record<string, unknown>;
+  /** Timestamp (ms since game start) */
+  timestamp: number;
+  /** Optional formatted description (set by game plugin) */
+  description?: string;
+}

--- a/shared/src/gamePlugin.ts
+++ b/shared/src/gamePlugin.ts
@@ -1,5 +1,6 @@
 import type { Schema } from "@colyseus/schema";
 import type { Client } from "colyseus";
+import type { MoveEntry } from "./MoveEntry.js";
 
 /**
  * The main interface that every game plugin must implement.
@@ -32,6 +33,9 @@ export interface GamePlugin<TState extends Schema = Schema> {
 
   /** State filtering for hidden information (optional) */
   stateFilter?: StateFilter<TState>;
+
+  /** Optional: format raw move entries into human-readable descriptions */
+  formatMoveHistory?(state: TState, moves: MoveEntry[]): MoveEntry[];
 }
 
 export interface GameMetadata {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -34,6 +34,7 @@ defineTypes(GameState, {
 });
 
 export { BaseGameState, PlayerInfo } from "./BaseGameState.js";
+export type { MoveEntry } from "./MoveEntry.js";
 
 // Shared constants
 export const GAME_WIDTH = 800;


### PR DESCRIPTION
## Summary

Fixes #155 — Dominos tiles placed in wrong position; adds clearer placement preview.

### What changed

**Bug fix: End position coordinates**
- Replaced hardcoded `8px` offset in end marker positions with scale-aware `BOARD_TILE_GAP * scale` computation
- Previously, markers appeared ~8px from the last tile regardless of scale, while actual tile placement was 60px+ away (tile width + gap). This caused the "tiles placed in wrong position" perception — the marker suggested one spot but the tile rendered elsewhere after board re-centering
- Now end positions point to the exact connecting edge where a new tile's face would meet the chain

**New feature: Ghost tile preview**
- When a player selects a tile and is choosing an end (A/B/C/D), a semi-transparent (alpha 0.4) "ghost" tile renders at the exact target position
- Ghost tiles show correct dimensions (regular vs double), correct orientation per arm direction, and correct pip values
- Ghost works in both linear (pre-spinner) and cross (post-spinner) layout modes

**End marker improvements**
- Markers now center themselves on the ghost tile area instead of using directional anchor offsets
- Click targets remain on the ghost tile, making it clear what clicking will do

### Layout state tracking
- Added instance variables for board scale, spinner center, and arm end edges so ghost position computation uses the same coordinate system as the board layout

### Validation
- `npm run build` ✅
- `npm run lint` ✅ (no new warnings)
- `npm run test` ✅ (506 tests pass)