### PR TITLE
feat: click-and-drag interaction for game pieces (#149)

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -723,3 +723,36 @@ npm run test   # ✅ 467 tests passed
 **Cross-agent coordination:** No other agents involved. Standalone renderer improvements.
 
 **Status:** P7 complete. Risk phase banner now matches Figma prominence. Dominos background already correct.
+
+## 2026-03-19: Click-and-Drag for Game Pieces (Issue #149, PR #160)
+
+### Deliverables:
+- **DragHelper** (`client/src/renderers/DragHelper.ts`): Reusable proxy-based drag utility with distance threshold (6px) to distinguish clicks from drags
+- **Checkers drag-to-move**: pointerdown on piece starts drag, proxy follows cursor at 1.15x scale, valid targets highlighted, drop sends move
+- **Dominos drag-to-play**: pointerdown on hand tile starts drag, valid board ends highlighted, closest end auto-resolved on drop
+- **DragHelper.test.ts**: 5 unit tests (threshold, promotion, drop accept/reject, cleanup)
+
+### Design decisions:
+- **Proxy-based (not target-based)**: Renderers draw all pieces in a single Graphics batch; DragHelper receives a pre-drawn proxy graphic instead of wrapping existing display objects. This avoids refactoring the piece rendering pipeline.
+- **Click fallback preserved**: The 6px threshold means quick taps still trigger the existing click-to-select/click-to-move flow. No regression to existing UX.
+- **Game logic stays in renderer**: DragHelper only handles pointer tracking and visual proxy. Validation (valid squares, valid ends) is entirely in renderer callbacks.
+
+### Key file paths:
+- `client/src/renderers/DragHelper.ts` (new, reusable utility)
+- `client/src/renderers/DragHelper.test.ts` (new, unit tests)
+- `client/src/renderers/CheckersRenderer.ts` (modified, drag integration)
+- `client/src/renderers/DominosRenderer.ts` (modified, drag integration)
+
+### Validation:
+```bash
+npm run build  # ✅ Passed
+npm run lint   # ✅ No new issues
+npm run test   # ✅ 472 tests passed (5 new)
+```
+
+## Learnings
+
+- Checkers pieces are rendered as a single `Graphics` batch in `piecesLayer` (eventMode "none"), so drag cannot be attached to individual piece containers. Proxy-based drag is the right pattern for this renderer architecture.
+- DominosRenderer recreates hand tile Graphics on every `redrawHand()` call, making registration-based drag impractical. Proxy approach works here too.
+- PixiJS `pointerdown` + `pointermove` + `pointerup` on a parent container handles both mouse and touch — no separate touch event handling needed.
+- The `container.eventMode = "static"` must be set on the renderer's root container for stage-level pointer events to propagate to the DragHelper.

--- a/.squad/agents/ortho/history.md
+++ b/.squad/agents/ortho/history.md
@@ -270,3 +270,41 @@
 - The lobby sidebar architecture was already complete with glass-morphism panels, proper data wiring, and interactive elements (join buttons, status badges)
 - Transition timing consistency across hover effects (300ms standard) creates smoother, more cohesive UX
 
+
+---
+
+## 2026-07-24: PR #160 Review Fixes — Complete ✅
+
+**Status:** Complete — PR #160 revision
+**Build:** ✅ Pass | **Lint:** ✅ Pass | **Test:** ✅ Pass (472 tests)
+
+### What was fixed
+
+**Problem:** Hal's review flagged two issues on Gately's PR #160 (branch `squad/149-drag-and-drop`):
+1. `ghostLayer` referenced in `container.addChild()` but never declared — would throw at runtime
+2. Memory leak in `redrawHand()` — each tile has `pointertap` + `pointerdown` listeners that weren't destroyed on redraw
+
+**Solution:**
+- Declared `ghostLayer` property: `private readonly ghostLayer = new Container();` (matching the pattern from other layers like `boardLayer`, `handLayer`, `dragLayer`)
+- Fixed memory leaks in three `removeChildren()` call sites:
+  - `redrawHand()` — destroy children before removing (prevents 2 listeners/tile leak)
+  - `redrawBoard()` — destroy children before removing
+  - `redrawEndMarkers()` — destroy children in all 4 end markers before removing
+- Followed codebase pattern: `for (const child of layer.removeChildren()) child.destroy()`
+
+**Files Modified:**
+- `client/src/renderers/DominosRenderer.ts` — Added ghostLayer property, fixed 3 memory leaks
+
+### Learnings
+
+- **PixiJS memory management pattern:** Always destroy removed children that have event listeners. The standard pattern is:
+  ```ts
+  for (const child of layer.removeChildren()) {
+    child.destroy();
+  }
+  ```
+  Not: `layer.removeChildren()` (leaks listeners).
+- **Layer declaration pattern:** All layers in `DominosRenderer` are `private readonly {name}Layer = new Container()` properties. `ghostLayer` needed the same treatment.
+- **Cross-branch dependencies:** `ghostLayer` is likely from PR #158 (not yet merged), but it's already referenced in this PR's code. Declaring it locally prevents runtime errors until #158 merges.
+- **Gately lockout protocol:** When Gately is locked out of revisions, I (Ortho) handle PixiJS renderer fixes. This was a clean handoff since the issues were isolated to the renderer file.
+

--- a/.squad/decisions/inbox/gately-drag-drop.md
+++ b/.squad/decisions/inbox/gately-drag-drop.md
@@ -1,0 +1,24 @@
+### Gately: Proxy-Based Drag Pattern for Game Renderers
+
+**Status:** Implemented
+**Date:** 2026-03-19
+**PR:** #160 (Issue #149)
+
+Use a proxy-based drag system (`DragHelper`) rather than registering individual display objects as draggable. The helper receives a pre-drawn `Graphics` proxy from the renderer and manages pointer tracking, while game-specific validation stays in renderer callbacks.
+
+**Rationale:**
+- Both Checkers and Dominos renderers batch-draw pieces into shared Graphics objects (piecesLayer / handLayer) — individual piece containers don't exist as addressable display objects
+- Proxy approach is non-invasive: no changes to the existing rendering pipeline, piece drawing, or state management
+- 6px distance threshold cleanly separates click vs. drag, preserving the existing click-to-move UX
+- Pattern extends naturally to future games (Backgammon bearing-off, Risk army placement)
+
+**Impact:**
+- Checkers and Dominos both support drag-and-drop with click fallback
+- Reusable across any future game renderer
+- No regression to existing click interactions
+
+**Files:**
+- `client/src/renderers/DragHelper.ts` (new utility)
+- `client/src/renderers/DragHelper.test.ts` (new tests)
+- `client/src/renderers/CheckersRenderer.ts` (integrated)
+- `client/src/renderers/DominosRenderer.ts` (integrated)

--- a/client/src/renderers/CheckersRenderer.ts
+++ b/client/src/renderers/CheckersRenderer.ts
@@ -16,6 +16,7 @@ import {
   type CheckersMove,
 } from "../games/checkers/checkersClientLogic";
 import { GameSidebar, escapeHtml, getTurnClockMarkup } from "../ui/GameSidebar";
+import { DragHelper } from "./DragHelper";
 import {
   ACCENT_BLUE,
   AMBER_500,
@@ -80,6 +81,7 @@ const CAPTURED_PIECE_TOTAL = 12;
 const CAPTURED_PIECES_PER_ROW = 6;
 const HOVER_PIECE_SCALE = 1.05;
 const SELECTED_PIECE_SCALE = 0.95;
+const DRAG_PIECE_SCALE = 1.15;
 const VIEW_PADDING = 24;
 const TOP_HUD_SPACE = 104;
 const BOTTOM_HUD_SPACE = 96;
@@ -118,6 +120,7 @@ export class CheckersRenderer implements GameRenderer {
   private readonly boardLayer = new Container();
   private readonly boardFrame = new Graphics();
   private readonly piecesLayer = new Container();
+  private readonly dragLayer = new Container();
   private readonly overlayLayer = new Container();
   private readonly overlayBackground = new Graphics();
   private readonly blackCountText = new Text({
@@ -181,6 +184,8 @@ export class CheckersRenderer implements GameRenderer {
   private validTargetIndexes = new Set<number>();
   private moveHistory: string[] = [];
   private isFlipped = false;
+  private dragHelper: DragHelper | null = null;
+  private dragSourceIndex: number | null = null;
   private width = DEFAULT_WIDTH;
   private height = DEFAULT_HEIGHT;
   private squareSize = Math.min(DEFAULT_WIDTH, DEFAULT_HEIGHT - TOP_HUD_SPACE - BOTTOM_HUD_SPACE)
@@ -191,8 +196,10 @@ export class CheckersRenderer implements GameRenderer {
     + ((DEFAULT_HEIGHT - TOP_HUD_SPACE - BOTTOM_HUD_SPACE - this.boardSize) / 2);
 
   constructor() {
+    this.container.eventMode = "static";
     this.piecesLayer.eventMode = "none";
     this.capturedPiecesGraphics.eventMode = "none";
+    this.dragLayer.eventMode = "none";
     this.overlayLayer.eventMode = "none";
     this.overlayLayer.visible = false;
     this.blackCountText.anchor.set(0, 0);
@@ -205,8 +212,8 @@ export class CheckersRenderer implements GameRenderer {
     for (let index = 0; index < BOARD_CELL_COUNT; index += 1) {
       const square = new Graphics();
       square.eventMode = "static";
-      square.on("pointertap", () => {
-        this.handleSquareClick(index);
+      square.on("pointerdown", (e) => {
+        this.handleSquarePointerDown(index, e);
       });
       square.on("pointerover", () => {
         this.handleSquareHover(index);
@@ -222,11 +229,18 @@ export class CheckersRenderer implements GameRenderer {
       this.boardFrame,
       this.boardLayer,
       this.piecesLayer,
+      this.dragLayer,
       this.capturedPiecesGraphics,
       this.blackCountText,
       this.redCountText,
       this.overlayLayer,
     );
+
+    this.dragHelper = new DragHelper(this.container, this.dragLayer, {
+      onDragMove: (_id, x, y) => this.handleDragMove(x, y),
+      onDrop: (id, x, y) => this.handleDragDrop(id, x, y),
+      onDragCancel: () => this.handleDragCancel(),
+    });
   }
 
   init(state: unknown, context?: GameRendererContext): void {
@@ -237,6 +251,8 @@ export class CheckersRenderer implements GameRenderer {
     this.selectedIndex = null;
     this.hoveredIndex = null;
     this.validTargetIndexes.clear();
+    this.dragHelper?.cancel();
+    this.dragSourceIndex = null;
     this.moveHistory = [];
     this.turnClockSeconds = null;
     this.showTurnClock = false;
@@ -257,6 +273,8 @@ export class CheckersRenderer implements GameRenderer {
   }
 
   onStateChange(state: unknown): void {
+    this.dragHelper?.cancel();
+    this.dragSourceIndex = null;
     this.applyState(state);
     this.syncSelectionWithState();
     this.redrawBoard();
@@ -300,6 +318,9 @@ export class CheckersRenderer implements GameRenderer {
 
   destroy(): void {
     this.unsubscribeFromRoomEvents();
+    this.dragHelper?.destroy();
+    this.dragHelper = null;
+    this.dragSourceIndex = null;
     this.room = null;
     this.requestLeave = null;
     this.players.clear();
@@ -583,6 +604,8 @@ export class CheckersRenderer implements GameRenderer {
   }
 
   private handleSquareHover(displayIndex: number | null): void {
+    if (this.dragHelper?.isDragging) return;
+
     const hoveredIndex = displayIndex === null ? null : this.toBoardIndex(displayIndex);
     const nextHoveredIndex = hoveredIndex !== null && this.isHoverablePiece(hoveredIndex)
       ? hoveredIndex
@@ -594,6 +617,42 @@ export class CheckersRenderer implements GameRenderer {
 
     this.hoveredIndex = nextHoveredIndex;
     this.redrawPieces();
+  }
+
+  private handleSquarePointerDown(displayIndex: number, e: import("pixi.js").FederatedPointerEvent): void {
+    const boardIndex = this.toBoardIndex(displayIndex);
+
+    if (!this.isLocalPlayersTurn()) {
+      if (this.selectedIndex !== null) {
+        this.clearSelection();
+      }
+      return;
+    }
+
+    // If clicking on a selectable piece, start a potential drag
+    if (this.isSelectableSquare(boardIndex)) {
+      this.setSelection(boardIndex);
+      this.dragSourceIndex = boardIndex;
+      const pos = this.container.toLocal(e.global);
+      const proxy = this.createDragProxy(boardIndex);
+      this.dragHelper?.beginDrag(String(boardIndex), proxy, pos.x, pos.y);
+      return;
+    }
+
+    // If a piece is selected and we click a valid target, execute the move
+    if (this.selectedIndex !== null && this.validTargetIndexes.has(boardIndex)) {
+      this.room?.send("move", { from: this.selectedIndex, to: boardIndex });
+      this.clearSelection();
+      return;
+    }
+
+    // Toggle selection off if clicking the same piece
+    if (this.selectedIndex === boardIndex) {
+      this.clearSelection();
+      return;
+    }
+
+    this.clearSelection();
   }
 
   private handleSquareClick(displayIndex: number): void {
@@ -624,6 +683,94 @@ export class CheckersRenderer implements GameRenderer {
     }
 
     this.clearSelection();
+  }
+
+  private createDragProxy(boardIndex: number): Graphics {
+    const piece = this.board[boardIndex];
+    const isBlackPiece = piece === BLACK || piece === BLACK_KING;
+    const radius = this.squareSize * 0.32 * DRAG_PIECE_SCALE;
+    const outlineWidth = Math.max(1, this.squareSize * 0.04);
+    const gradient = createPieceBodyGradient(isBlackPiece ? "black" : "red");
+    const border = isBlackPiece ? PIECE_BLACK_BORDER : PIECE_RED_BORDER;
+    const glow = isBlackPiece ? PIECE_BLACK_GLOW : PIECE_RED_GLOW;
+    const highlight = createPieceHighlightGradient();
+
+    const g = new Graphics();
+    g.circle(0, 0, radius * 1.08).fill({ color: glow, alpha: 0.3 });
+    g.circle(0, 0, radius).fill(gradient).stroke({ color: border, width: outlineWidth });
+    g.circle(-(radius * 0.15), -(radius * 0.2), radius * 0.38).fill(highlight);
+
+    if (piece === BLACK_KING || piece === RED_KING) {
+      g.circle(0, 0, radius * 0.64).stroke({
+        color: KING_CROWN_SHADOW,
+        alpha: KING_CROWN_SHADOW_ALPHA,
+        width: Math.max(4, outlineWidth + 3),
+      });
+      g.circle(0, 0, radius * 0.58).stroke({
+        color: KING_MARKER_COLOR,
+        alpha: KING_CROWN_RING_ALPHA,
+        width: Math.max(3, this.squareSize * 0.05),
+      });
+    }
+
+    return g;
+  }
+
+  private handleDragMove(x: number, y: number): void {
+    // Highlight the square under the cursor if it's a valid target
+    const displayIndex = this.getDisplayIndexAtPoint(x, y);
+    if (displayIndex !== null) {
+      const boardIndex = this.toBoardIndex(displayIndex);
+      if (this.validTargetIndexes.has(boardIndex)) {
+        this.hoveredIndex = boardIndex;
+        this.redrawBoard();
+        return;
+      }
+    }
+    if (this.hoveredIndex !== null) {
+      this.hoveredIndex = null;
+      this.redrawBoard();
+    }
+  }
+
+  private handleDragDrop(id: string, x: number, y: number): boolean {
+    const fromIndex = Number(id);
+    const displayIndex = this.getDisplayIndexAtPoint(x, y);
+
+    this.hoveredIndex = null;
+    this.dragSourceIndex = null;
+
+    if (displayIndex !== null) {
+      const targetIndex = this.toBoardIndex(displayIndex);
+      if (this.validTargetIndexes.has(targetIndex)) {
+        this.room?.send("move", { from: fromIndex, to: targetIndex });
+        this.clearSelection();
+        this.redrawBoard();
+        this.redrawPieces();
+        return true;
+      }
+    }
+
+    // Invalid drop — selection stays so player can click a target instead
+    this.redrawBoard();
+    this.redrawPieces();
+    return false;
+  }
+
+  private handleDragCancel(): void {
+    this.hoveredIndex = null;
+    this.dragSourceIndex = null;
+    this.redrawBoard();
+    this.redrawPieces();
+  }
+
+  private getDisplayIndexAtPoint(x: number, y: number): number | null {
+    const col = Math.floor((x - this.boardOffsetX) / this.squareSize);
+    const row = Math.floor((y - this.boardOffsetY) / this.squareSize);
+    if (col < 0 || col >= BOARD_DIMENSION || row < 0 || row >= BOARD_DIMENSION) {
+      return null;
+    }
+    return row * BOARD_DIMENSION + col;
   }
 
   private subscribeToRoomEvents(): void {

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -139,6 +139,7 @@ export class DominosRenderer implements GameRenderer {
   // ── Layers ──────────────────────────────────────────────────────────────
   private readonly boardBackground = new Graphics();
   private readonly boardLayer = new Container();
+  private readonly ghostLayer = new Container();
   private readonly handLayer = new Container();
   private readonly dragLayer = new Container();
   private readonly overlayLayer = new Container();
@@ -777,7 +778,9 @@ export class DominosRenderer implements GameRenderer {
   // ═══════════════════════════════════════════════════════════════════════════
 
   private redrawBoard(): void {
-    this.boardLayer.removeChildren();
+    for (const child of this.boardLayer.removeChildren()) {
+      child.destroy();
+    }
 
     if (this.boardTiles.length === 0) {
       const emptyText = new Text({
@@ -1065,10 +1068,18 @@ export class DominosRenderer implements GameRenderer {
     this.endMarkerB.clear();
     this.endMarkerC.clear();
     this.endMarkerD.clear();
-    this.endMarkerA.removeChildren();
-    this.endMarkerB.removeChildren();
-    this.endMarkerC.removeChildren();
-    this.endMarkerD.removeChildren();
+    for (const child of this.endMarkerA.removeChildren()) {
+      child.destroy();
+    }
+    for (const child of this.endMarkerB.removeChildren()) {
+      child.destroy();
+    }
+    for (const child of this.endMarkerC.removeChildren()) {
+      child.destroy();
+    }
+    for (const child of this.endMarkerD.removeChildren()) {
+      child.destroy();
+    }
     this.endMarkerA.visible = false;
     this.endMarkerB.visible = false;
     this.endMarkerC.visible = false;
@@ -1162,7 +1173,9 @@ export class DominosRenderer implements GameRenderer {
   // ═══════════════════════════════════════════════════════════════════════════
 
   private redrawHand(): void {
-    this.handLayer.removeChildren();
+    for (const child of this.handLayer.removeChildren()) {
+      child.destroy();
+    }
 
     const hand = this.getMyHand();
     const handY = this.height - HAND_AREA_HEIGHT;

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -6,6 +6,7 @@ import type {
 } from "@eschaton/shared";
 import { Container, Graphics, Text } from "pixi.js";
 import { GameSidebar, escapeHtml, getTurnClockMarkup } from "../ui/GameSidebar";
+import { DragHelper } from "./DragHelper";
 import {
   ACCENT_BLUE,
   AMBER_500,
@@ -139,6 +140,7 @@ export class DominosRenderer implements GameRenderer {
   private readonly boardBackground = new Graphics();
   private readonly boardLayer = new Container();
   private readonly handLayer = new Container();
+  private readonly dragLayer = new Container();
   private readonly overlayLayer = new Container();
   private readonly overlayBackground = new Graphics();
   private readonly overlayTitleText = new Text({
@@ -221,9 +223,13 @@ export class DominosRenderer implements GameRenderer {
   };
   private width = DEFAULT_WIDTH;
   private height = DEFAULT_HEIGHT;
+  private dragHelper: DragHelper | null = null;
+  private dragTileId: number | null = null;
 
   constructor() {
+    this.container.eventMode = "static";
     this.overlayLayer.eventMode = "none";
+    this.dragLayer.eventMode = "none";
     this.overlayLayer.visible = false;
     this.overlayTitleText.anchor.set(0.5);
     this.overlaySubtitleText.anchor.set(0.5);
@@ -252,6 +258,7 @@ export class DominosRenderer implements GameRenderer {
     this.container.addChild(
       this.boardBackground,
       this.boardLayer,
+      this.ghostLayer,
       this.endMarkerA,
       this.endMarkerB,
       this.endMarkerC,
@@ -260,8 +267,15 @@ export class DominosRenderer implements GameRenderer {
       this.boneyardLabel,
       this.boneyardCountText,
       this.handLayer,
+      this.dragLayer,
       this.overlayLayer,
     );
+
+    this.dragHelper = new DragHelper(this.container, this.dragLayer, {
+      onDragMove: (_id, x, y) => this.handleTileDragMove(x, y),
+      onDrop: (id, x, y) => this.handleTileDrop(id, x, y),
+      onDragCancel: () => this.handleTileDragCancel(),
+    });
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -275,6 +289,8 @@ export class DominosRenderer implements GameRenderer {
     this.gameResult = null;
     this.selectedTileId = null;
     this.choosingEnd = false;
+    this.dragHelper?.cancel();
+    this.dragTileId = null;
     this.turnClockSeconds = null;
     this.showTurnClock = false;
 
@@ -293,6 +309,8 @@ export class DominosRenderer implements GameRenderer {
   }
 
   onStateChange(state: unknown): void {
+    this.dragHelper?.cancel();
+    this.dragTileId = null;
     this.applyState(state);
     this.syncSelection();
     this.redrawAll();
@@ -330,6 +348,9 @@ export class DominosRenderer implements GameRenderer {
 
   destroy(): void {
     this.unsubscribeFromRoomEvents();
+    this.dragHelper?.destroy();
+    this.dragHelper = null;
+    this.dragTileId = null;
     this.room = null;
     this.requestLeave = null;
     this.players.clear();
@@ -539,6 +560,171 @@ export class DominosRenderer implements GameRenderer {
     this.validEnds = [];
     this.room?.send(type, {});
     this.redrawAll();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Drag-and-drop from hand to board
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private onTilePointerDown(tileId: number, e: import("pixi.js").FederatedPointerEvent): void {
+    if (!this.isLocalPlayersTurn()) return;
+
+    const tile = this.getMyHand().find((t) => t.id === tileId);
+    if (!tile) return;
+
+    this.dragTileId = tileId;
+
+    // Compute valid ends for this tile
+    const ends = this.getValidEndsForTile(tile);
+
+    const pos = this.container.toLocal(e.global);
+    const proxy = this.createTileDragProxy(tile);
+    this.dragHelper?.beginDrag(String(tileId), proxy, pos.x, pos.y);
+
+    // If tile has valid ends, highlight them during drag
+    if (ends.length > 0 && this.boardTiles.length > 0) {
+      this.validEnds = ends;
+      this.choosingEnd = true;
+      this.redrawEndMarkers();
+    }
+  }
+
+  private getValidEndsForTile(tile: HandTile): ("a" | "b" | "c" | "d")[] {
+    if (this.boardTiles.length === 0) return ["a"];
+    const ends: ("a" | "b" | "c" | "d")[] = [];
+    if (this.canPlayOnEnd(tile, this.openEndA)) ends.push("a");
+    if (this.canPlayOnEnd(tile, this.openEndB)) ends.push("b");
+    if (this.openEndC >= 0 && this.canPlayOnEnd(tile, this.openEndC)) ends.push("c");
+    if (this.openEndD >= 0 && this.canPlayOnEnd(tile, this.openEndD)) ends.push("d");
+    return ends;
+  }
+
+  private createTileDragProxy(tile: HandTile): Graphics {
+    const g = new Graphics();
+    const w = TILE_WIDTH;
+    const h = TILE_HEIGHT;
+
+    // Draw tile centered at (0,0)
+    g.roundRect(-w / 2, -h / 2, w, h, TILE_RADIUS)
+      .fill(TILE_BG)
+      .stroke({ color: TILE_SELECTED_BORDER, width: 2 });
+
+    // Divider
+    g.moveTo(-w / 2 + 4, 0)
+      .lineTo(w / 2 - 4, 0)
+      .stroke({ color: TILE_DIVIDER_COLOR, width: 1 });
+
+    // Pips
+    this.drawPipsVertical(g, tile.highPips, -w / 2, -h / 2, w, TILE_HALF);
+    this.drawPipsVertical(g, tile.lowPips, -w / 2, 0, w, TILE_HALF);
+
+    g.alpha = 0.85;
+    return g;
+  }
+
+  private handleTileDragMove(x: number, y: number): void {
+    // Highlight the nearest valid end marker when dragging over the board area
+    if (!this.dragTileId) return;
+
+    const tile = this.getMyHand().find((t) => t.id === this.dragTileId);
+    if (!tile) return;
+
+    const ends = this.getValidEndsForTile(tile);
+    if (ends.length > 0 && this.boardTiles.length > 0) {
+      this.validEnds = ends;
+      this.choosingEnd = true;
+      this.redrawEndMarkers();
+    }
+
+    // Check proximity to end markers for visual feedback
+    const boardY = this.height - HAND_AREA_HEIGHT - BOTTOM_HUD_SPACE;
+    if (y < boardY) {
+      // Cursor is over the board area — end markers are already highlighted
+      return;
+    }
+  }
+
+  private handleTileDrop(id: string, x: number, y: number): boolean {
+    const tileId = Number(id);
+    const tile = this.getMyHand().find((t) => t.id === tileId);
+    this.dragTileId = null;
+
+    if (!tile) {
+      this.choosingEnd = false;
+      this.validEnds = [];
+      this.redrawAll();
+      return false;
+    }
+
+    // Empty board — auto-play
+    if (this.boardTiles.length === 0) {
+      const ends = this.getValidEndsForTile(tile);
+      if (ends.length > 0) {
+        this.sendPlay(tileId, ends[0]);
+        return true;
+      }
+      this.choosingEnd = false;
+      this.validEnds = [];
+      this.redrawAll();
+      return false;
+    }
+
+    // Find the nearest valid end to the drop point
+    const ends = this.getValidEndsForTile(tile);
+    if (ends.length === 0) {
+      this.choosingEnd = false;
+      this.validEnds = [];
+      this.redrawAll();
+      return false;
+    }
+
+    if (ends.length === 1) {
+      this.sendPlay(tileId, ends[0]);
+      return true;
+    }
+
+    // Multiple valid ends — find the closest one to the drop position
+    const closest = this.findClosestEnd(ends, x, y);
+    if (closest) {
+      this.sendPlay(tileId, closest);
+      return true;
+    }
+
+    // Couldn't resolve — fall back to click-based end choice
+    this.selectedTileId = tileId;
+    this.validEnds = ends;
+    this.choosingEnd = true;
+    this.redrawAll();
+    return false;
+  }
+
+  private handleTileDragCancel(): void {
+    this.dragTileId = null;
+    this.choosingEnd = false;
+    this.validEnds = [];
+    this.redrawAll();
+  }
+
+  private findClosestEnd(
+    ends: ("a" | "b" | "c" | "d")[],
+    x: number,
+    y: number,
+  ): "a" | "b" | "c" | "d" | null {
+    let best: "a" | "b" | "c" | "d" | null = null;
+    let bestDist = Infinity;
+
+    for (const end of ends) {
+      const pos = this.endPositions[end];
+      const dx = x - pos.x;
+      const dy = y - pos.y;
+      const dist = dx * dx + dy * dy;
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = end;
+      }
+    }
+
+    return best;
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1017,6 +1203,9 @@ export class DominosRenderer implements GameRenderer {
       g.eventMode = "static";
       g.cursor = this.isLocalPlayersTurn() ? "pointer" : "default";
       g.on("pointertap", () => this.onTileClick(tile.id));
+      g.on("pointerdown", (e: import("pixi.js").FederatedPointerEvent) => {
+        this.onTilePointerDown(tile.id, e);
+      });
       this.handLayer.addChild(g);
     }
 

--- a/client/src/renderers/DragHelper.test.ts
+++ b/client/src/renderers/DragHelper.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { Container, Graphics, EventEmitter } from "pixi.js";
+import { DragHelper } from "./DragHelper";
+
+// Minimal mock helpers — DragHelper only needs Container event methods and toLocal
+function createMockStage(): Container {
+  const emitter = new EventEmitter();
+  const stage = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      emitter.on(event, handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      emitter.off(event, handler);
+    }),
+    toLocal: vi.fn((global: { x: number; y: number }) => ({ x: global.x, y: global.y })),
+    addChild: vi.fn(),
+    emit: (event: string, ...args: unknown[]) => emitter.emit(event, ...args),
+  };
+  return stage as unknown as Container;
+}
+
+function createMockDragLayer(): Container {
+  return {
+    addChild: vi.fn(),
+    eventMode: "none",
+  } as unknown as Container;
+}
+
+function createProxy(): Graphics {
+  return {
+    eventMode: "none",
+    visible: false,
+    position: { set: vi.fn() },
+    destroy: vi.fn(),
+    getLocalBounds: vi.fn(() => ({ x: -20, y: -20, width: 40, height: 40 })),
+  } as unknown as Graphics;
+}
+
+describe("DragHelper", () => {
+  it("begins in non-dragging state", () => {
+    const stage = createMockStage();
+    const layer = createMockDragLayer();
+    const helper = new DragHelper(stage, layer, {});
+
+    expect(helper.isDragging).toBe(false);
+    expect(helper.draggingId).toBeNull();
+
+    helper.destroy();
+  });
+
+  it("tracks a pending drag without promoting below threshold", () => {
+    const stage = createMockStage();
+    const layer = createMockDragLayer();
+    const onDrop = vi.fn(() => true);
+    const helper = new DragHelper(stage, layer, { onDrop });
+
+    const proxy = createProxy();
+    helper.beginDrag("piece-1", proxy, 100, 100);
+
+    expect(helper.draggingId).toBe("piece-1");
+    expect(helper.isDragging).toBe(false); // not promoted yet
+
+    // Small move below threshold (< 6px)
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointermove", {
+      global: { x: 102, y: 102 },
+    });
+    expect(helper.isDragging).toBe(false);
+
+    // Release — should be treated as click, not drop
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointerup", {
+      global: { x: 102, y: 102 },
+    });
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(helper.isDragging).toBe(false);
+    expect(helper.draggingId).toBeNull();
+
+    helper.destroy();
+  });
+
+  it("promotes to drag after exceeding threshold and calls onDrop", () => {
+    const stage = createMockStage();
+    const layer = createMockDragLayer();
+    const onDragMove = vi.fn();
+    const onDrop = vi.fn(() => true);
+    const helper = new DragHelper(stage, layer, { onDragMove, onDrop });
+
+    const proxy = createProxy();
+    helper.beginDrag("piece-2", proxy, 100, 100);
+
+    // Move past threshold (> 6px)
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointermove", {
+      global: { x: 120, y: 120 },
+    });
+    expect(helper.isDragging).toBe(true);
+    expect(onDragMove).toHaveBeenCalledWith("piece-2", 120, 120);
+
+    // Drop
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointerup", {
+      global: { x: 150, y: 150 },
+    });
+    expect(onDrop).toHaveBeenCalledWith("piece-2", 150, 150);
+    expect(helper.isDragging).toBe(false);
+
+    helper.destroy();
+  });
+
+  it("calls onDragCancel when drop is rejected", () => {
+    const stage = createMockStage();
+    const layer = createMockDragLayer();
+    const onDrop = vi.fn(() => false);
+    const onDragCancel = vi.fn();
+    const helper = new DragHelper(stage, layer, { onDrop, onDragCancel });
+
+    const proxy = createProxy();
+    helper.beginDrag("piece-3", proxy, 50, 50);
+
+    // Move past threshold
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointermove", {
+      global: { x: 80, y: 80 },
+    });
+
+    // Drop rejected
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointerup", {
+      global: { x: 80, y: 80 },
+    });
+    expect(onDrop).toHaveBeenCalled();
+    expect(onDragCancel).toHaveBeenCalledWith("piece-3");
+
+    helper.destroy();
+  });
+
+  it("cancel() cleans up active drag", () => {
+    const stage = createMockStage();
+    const layer = createMockDragLayer();
+    const onDragCancel = vi.fn();
+    const helper = new DragHelper(stage, layer, { onDragCancel });
+
+    const proxy = createProxy();
+    helper.beginDrag("piece-4", proxy, 0, 0);
+
+    // Move past threshold to promote
+    (stage as unknown as { emit: (event: string, ...args: unknown[]) => void }).emit("pointermove", {
+      global: { x: 50, y: 50 },
+    });
+    expect(helper.isDragging).toBe(true);
+
+    helper.cancel();
+    expect(helper.isDragging).toBe(false);
+    expect(helper.draggingId).toBeNull();
+    expect(onDragCancel).toHaveBeenCalledWith("piece-4");
+
+    helper.destroy();
+  });
+});

--- a/client/src/renderers/DragHelper.ts
+++ b/client/src/renderers/DragHelper.ts
@@ -1,0 +1,188 @@
+import { Container, Graphics, type FederatedPointerEvent } from "pixi.js";
+
+// Minimum drag distance (px) before a pointerdown is promoted from click to drag
+const DRAG_THRESHOLD = 6;
+
+export interface DragCallbacks {
+  /** Called each frame while dragging. Use to highlight valid drop targets. */
+  onDragMove?: (id: string, x: number, y: number) => void;
+  /** Called when the piece is released. Return true if the drop was accepted. */
+  onDrop?: (id: string, x: number, y: number) => boolean;
+  /** Called when a drag is cancelled (drop rejected or threshold not met). */
+  onDragCancel?: (id: string) => void;
+}
+
+interface ActiveDrag {
+  id: string;
+  proxy: Graphics;
+  shadow: Graphics;
+  startX: number;
+  startY: number;
+  promoted: boolean;
+}
+
+/**
+ * Proxy-based drag helper for PixiJS game renderers.
+ *
+ * The renderer decides when to initiate a drag and provides a visual proxy
+ * graphic. DragHelper manages moving that proxy, rendering a drop shadow,
+ * and firing callbacks on move/drop/cancel.
+ *
+ * Distinguishes click vs. drag via a distance threshold so existing
+ * click-to-move interactions continue to work as fallback.
+ *
+ * Usage (in a renderer):
+ *   // In constructor:
+ *   this.drag = new DragHelper(this.container, this.dragLayer, callbacks);
+ *
+ *   // On pointerdown:
+ *   const proxy = this.drawPieceProxy(index);
+ *   this.drag.beginDrag("piece-5", proxy, pointerX, pointerY);
+ *
+ *   // In destroy():
+ *   this.drag.destroy();
+ */
+export class DragHelper {
+  private readonly stage: Container;
+  private readonly layer: Container;
+  private readonly callbacks: Required<DragCallbacks>;
+  private active: ActiveDrag | null = null;
+
+  private readonly boundMove: (e: FederatedPointerEvent) => void;
+  private readonly boundUp: (e: FederatedPointerEvent) => void;
+
+  constructor(stage: Container, dragLayer: Container, callbacks: DragCallbacks) {
+    this.stage = stage;
+    this.layer = dragLayer;
+    this.callbacks = {
+      onDragMove: callbacks.onDragMove ?? (() => {}),
+      onDrop: callbacks.onDrop ?? (() => true),
+      onDragCancel: callbacks.onDragCancel ?? (() => {}),
+    };
+
+    this.boundMove = this.handlePointerMove.bind(this);
+    this.boundUp = this.handlePointerUp.bind(this);
+
+    this.stage.on("pointermove", this.boundMove);
+    this.stage.on("pointerup", this.boundUp);
+    this.stage.on("pointerupoutside", this.boundUp);
+  }
+
+  /** Whether a drag has been promoted (moved past threshold). */
+  get isDragging(): boolean {
+    return this.active?.promoted === true;
+  }
+
+  /** The id of the piece currently being tracked, or null. */
+  get draggingId(): string | null {
+    return this.active?.id ?? null;
+  }
+
+  /**
+   * Begin tracking a potential drag. The proxy is hidden until the pointer
+   * moves past the drag threshold, at which point it becomes visible.
+   */
+  beginDrag(id: string, proxy: Graphics, startX: number, startY: number): void {
+    this.cancel();
+
+    proxy.eventMode = "none";
+    proxy.visible = false;
+
+    const shadow = new Graphics();
+    shadow.eventMode = "none";
+    shadow.visible = false;
+
+    this.layer.addChild(shadow);
+    this.layer.addChild(proxy);
+
+    this.active = { id, proxy, shadow, startX, startY, promoted: false };
+  }
+
+  /** Cancel any in-progress or pending drag. */
+  cancel(): void {
+    if (!this.active) return;
+    const { id, proxy, shadow, promoted } = this.active;
+    proxy.destroy();
+    shadow.destroy();
+    this.active = null;
+    if (promoted) {
+      this.callbacks.onDragCancel(id);
+    }
+  }
+
+  /** Returns true if a drag was pending but never promoted (i.e. it was a click). */
+  wasPendingClick(): boolean {
+    return this.active !== null && !this.active.promoted;
+  }
+
+  /** Full cleanup — call in the renderer's destroy(). */
+  destroy(): void {
+    this.cancel();
+    this.stage.off("pointermove", this.boundMove);
+    this.stage.off("pointerup", this.boundUp);
+    this.stage.off("pointerupoutside", this.boundUp);
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private handlePointerMove(e: FederatedPointerEvent): void {
+    if (!this.active) return;
+
+    const pos = this.stage.toLocal(e.global);
+
+    if (!this.active.promoted) {
+      const dx = pos.x - this.active.startX;
+      const dy = pos.y - this.active.startY;
+      if (Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD) return;
+
+      // Promote to a real drag
+      this.active.promoted = true;
+      this.active.proxy.visible = true;
+      this.active.shadow.visible = true;
+    }
+
+    this.active.proxy.position.set(pos.x, pos.y);
+    this.updateShadow(pos.x, pos.y);
+    this.callbacks.onDragMove(this.active.id, pos.x, pos.y);
+  }
+
+  private handlePointerUp(e: FederatedPointerEvent): void {
+    if (!this.active) return;
+
+    if (!this.active.promoted) {
+      // Never exceeded threshold — treat as click (caller handles via wasPendingClick check)
+      const { proxy, shadow } = this.active;
+      proxy.destroy();
+      shadow.destroy();
+      this.active = null;
+      return;
+    }
+
+    const pos = this.stage.toLocal(e.global);
+    const { id, proxy, shadow } = this.active;
+    const accepted = this.callbacks.onDrop(id, pos.x, pos.y);
+
+    proxy.destroy();
+    shadow.destroy();
+    this.active = null;
+
+    if (!accepted) {
+      this.callbacks.onDragCancel(id);
+    }
+  }
+
+  private updateShadow(x: number, y: number): void {
+    if (!this.active) return;
+    const { shadow, proxy } = this.active;
+    shadow.clear();
+    const bounds = proxy.getLocalBounds();
+    const offset = 4;
+    shadow
+      .roundRect(
+        x + bounds.x + offset,
+        y + bounds.y + offset,
+        bounds.width, bounds.height, 6,
+      )
+      .fill({ color: 0x000000, alpha: 0.22 });
+  }
+}


### PR DESCRIPTION
Closes #149

## Summary

Adds click-and-drag support for game pieces across Checkers and Dominos, with a reusable `DragHelper` utility that any renderer can adopt.

## Changes

### New: `DragHelper` (`client/src/renderers/DragHelper.ts`)
- Proxy-based drag utility — renderers provide a visual proxy graphic, DragHelper manages movement and lifecycle
- 6px distance threshold distinguishes clicks from drags, preserving existing click interactions
- Callbacks: `onDragMove`, `onDrop`, `onDragCancel` — game-specific validation stays in the renderer
- Touch support via PixiJS unified pointer events

### Checkers
- **Drag a piece** to a valid square to make a move
- Drag proxy shows a 1.15x scaled piece with drop shadow
- Valid target squares highlighted while dragging
- **Click-to-select, click-to-move still works** as fallback

### Dominos
- **Drag a tile** from your hand toward the board to play it
- Valid board ends highlighted as drop targets during drag
- On drop, automatically resolves the closest valid end
- If ambiguous, falls back to the existing end-choice UI
- **Tap-to-select interaction preserved**

### Tests
- 5 new unit tests for DragHelper (threshold, promotion, acceptance, rejection, cleanup)
- All existing tests pass (472 passed, 12 todo)
- Build and lint green