### PR TITLE
UX fixes: button hit areas, browser-back cleanup, spinner arm indicators

### DIFF
--- a/.squad/agents/gately/history.md
+++ b/.squad/agents/gately/history.md
@@ -2227,3 +2227,28 @@ Added double-click protection and pending-state guards to all four game renderer
 **Outcome:** 803 tests passing. Build/lint clean. No regressions.
 
 **Cross-agent sync:** Ortho implemented same pattern on DOM buttons (LobbyScreen, SetupScreen, WaitingRoom). Ensures consistency across canvas and DOM layers.
+
+## Session Update: 2026-03-22 — Browser Back/Tab Close Lobby Cleanup
+
+**Summary:** Fixed stale lobby state when user navigates away via browser back button, tab close, or refresh.
+
+**Root Cause:** The `beforeunload`/`pagehide` handlers only called `persistSessionForRefresh()` — they saved the game session for reconnection but never cleaned up the lobby connection. When the WebSocket dropped naturally (non-consented close), the server's `onLeave()` entered a 30-second reconnection window, keeping the player's `currentGameId` and online status alive.
+
+**Fix (client-side only — server was already correct):**
+- Added `handlePageUnload()` method that: (1) persists the game session, (2) explicitly calls `lobbyRoom.leave()` with a consented close
+- Consented close triggers server's `removeSession()` immediately (no 30s wait)
+- Game room intentionally left open — its natural WebSocket drop gives the server a 30s reconnection window for refresh recovery via `tryRestoreActiveSession()`
+- Added `isPageUnloading` flag to prevent `handleLobbyRoomLeave()` from starting reconnection during teardown
+
+**Key Insight:** The server's `LobbyRoom.onLeave()` + `removeSession()` already handles full cleanup correctly. The issue was purely that the client never sent a consented close for the lobby during page unload.
+
+**Files Modified:**
+- `client/src/Application.ts`
+
+## Learnings
+- `LobbyRoom.onLeave()`: non-consented close → 30s reconnection window; consented close → immediate `removeSession()`. The reconnection window is the source of stale lobby state when WebSocket drops naturally.
+- `removeSession()` calls `handleLeaveGame()` which properly clears `currentGameId` and removes from waiting players.
+- `reclaimSession()` migrates old sessions to new ones on reconnect, carrying forward `currentGameId` and waiting room membership.
+- `room.leave()` (Colyseus SDK) defaults to `consented=true`, sending a CONSENTED close frame. Usable in `pagehide`/`beforeunload` as a best-effort synchronous close.
+- Game room reconnection is stored in `sessionStorage` via `persistActiveSession()` and restored by `tryRestoreActiveSession()` — this is separate from lobby reconnection.
+- Lobby connections are always fresh on page load (no lobby reconnection persistence) — so leaving the lobby on page unload is always safe.

--- a/client/index.html
+++ b/client/index.html
@@ -1149,7 +1149,6 @@
       .waiting-room-add-cpu {
         border: 2px dashed rgba(255, 255, 255, 0.2);
         border-radius: 8px;
-        padding: 12px 16px;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -1167,7 +1166,8 @@
         color: rgba(255, 255, 255, 0.6);
         font-size: 0.92rem;
         cursor: pointer;
-        padding: 0;
+        padding: 12px 16px;
+        width: 100%;
         font-family: inherit;
       }
       .waiting-room-add-cpu:hover .waiting-room-add-cpu-btn {

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid-client",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/Application.ts
+++ b/client/src/Application.ts
@@ -107,6 +107,7 @@ export class PlaygridApp {
   private displayName = "";
   private lobbyPlayerId = "";
   private activeGameType: string | null = null;
+  private isPageUnloading = false;
   private isDisplayNameUpdatePending = false;
   private gameContainer: HTMLElement | null = null;
   private gameCanvasFrame: HTMLElement | null = null;
@@ -207,8 +208,8 @@ export class PlaygridApp {
     this.lobbyScene.setConsoleLog(this.consoleLog);
     this.setupScene.setConsoleLog(this.consoleLog);
     this.waitingRoomScene.setConsoleLog(this.consoleLog);
-    window.addEventListener("beforeunload", () => this.persistSessionForRefresh());
-    window.addEventListener("pagehide", () => this.persistSessionForRefresh());
+    window.addEventListener("beforeunload", () => this.handlePageUnload());
+    window.addEventListener("pagehide", () => this.handlePageUnload());
     window.addEventListener("resize", () => this.scheduleViewportSync());
     window.addEventListener(GAME_LAYOUT_CHANGE_EVENT, () => this.scheduleViewportSync());
     this.observeGameContainer(canvasFrame);
@@ -596,6 +597,12 @@ export class PlaygridApp {
 
     console.log(`[playgrid] Left lobby room (code: ${code})`);
     this.lobbyRoom = null;
+
+    // During page unload we intentionally left the lobby; skip reconnection.
+    if (this.isPageUnloading) {
+      return;
+    }
+
     this.waitingRoomScene.hideOverlay();
     this.setupScene.hideOverlay();
     this.lobbyScene.showConnectionError("Lost connection to the lobby room.");
@@ -737,6 +744,28 @@ export class PlaygridApp {
     this.clearReconnectOverlayHideTimeout();
     this.clearReconnectReturnTimeout();
     this.reconnectOverlay.hide();
+  }
+
+  /**
+   * Handle page unload (browser back, tab close, refresh).
+   * Persist the game session for reconnection, then explicitly leave the
+   * lobby room so the server cleans up immediately instead of waiting for
+   * the 30-second reconnection timeout.
+   */
+  private handlePageUnload(): void {
+    this.isPageUnloading = true;
+    this.persistSessionForRefresh();
+
+    // Leave the lobby room with a consented close so the server runs
+    // removeSession() immediately, clearing the player's game assignment
+    // and online-player list. The game room is intentionally left open —
+    // its natural WebSocket drop gives the server a 30-second reconnection
+    // window, which tryRestoreActiveSession() uses on page refresh.
+    try {
+      this.lobbyRoom?.leave();
+    } catch {
+      // Best-effort during page teardown.
+    }
   }
 
   private persistSessionForRefresh(): void {

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -70,6 +70,19 @@ const END_MARKER_COLOR = ACCENT_BLUE;
 const END_MARKER_ACTIVE_ALPHA = 0.85;
 const END_LABEL_FONT_SIZE = 14;
 
+// Spinner arm indicators (C/D arm discoverability)
+const SPINNER_IND_LENGTH = 28;
+const SPINNER_IND_DASH_LEN = 5;
+const SPINNER_IND_GAP_LEN = 4;
+const SPINNER_IND_ARROW_SIZE = 5;
+const SPINNER_IND_LOCKED_COLOR = SLATE_700;
+const SPINNER_IND_LOCKED_ALPHA = 0.35;
+const SPINNER_IND_ACTIVE_COLOR = ACCENT_BLUE;
+const SPINNER_IND_ACTIVE_ALPHA = 0.6;
+const SPINNER_IND_FLASH_COLOR = BLUE_400;
+const SPINNER_IND_FLASH_ALPHA = 1.0;
+const SPINNER_UNLOCK_FLASH_MS = 1500;
+
 const BONEYARD_BG = BG_CARD;
 const BONEYARD_BORDER = BORDER_LIGHT;
 const BONEYARD_RADIUS = 10;
@@ -241,6 +254,11 @@ export class DominosRenderer implements GameRenderer {
   private linearCenterY = 0;
   private layoutMode: "empty" | "linear" | "cross" = "empty";
 
+  // Spinner arm indicators (C/D discoverability)
+  private readonly spinnerIndicatorLayer = new Container();
+  private prevArmsCDLocked = true;
+  private spinnerUnlockFlashTimer = 0;
+
   constructor() {
     this.container.eventMode = "static";
     this.overlayLayer.eventMode = "none";
@@ -273,6 +291,7 @@ export class DominosRenderer implements GameRenderer {
     this.container.addChild(
       this.boardBackground,
       this.boardLayer,
+      this.spinnerIndicatorLayer,
       this.ghostLayer,
       this.endMarkerA,
       this.endMarkerB,
@@ -325,7 +344,17 @@ export class DominosRenderer implements GameRenderer {
 
   onStateChange(state: unknown): void {
     this.actionPending = false;
+
+    // Detect C/D arm unlock transition (locked → active)
+    const wasCDLocked = this.openEndC < 0 && this.openEndD < 0;
+
     this.applyState(state);
+
+    const isCDActive = this.openEndC >= 0 || this.openEndD >= 0;
+    if (wasCDLocked && isCDActive && this.spinnerTileId !== -1) {
+      this.spinnerUnlockFlashTimer = SPINNER_UNLOCK_FLASH_MS;
+    }
+
     this.syncSelection();
 
     // Only cancel a drag if the tile is no longer in hand or it's no longer our turn.
@@ -341,8 +370,14 @@ export class DominosRenderer implements GameRenderer {
     this.redrawAll();
   }
 
-  update(_deltaTime: number): void {
-    // No per-frame animation needed currently
+  update(deltaTime: number): void {
+    if (this.spinnerUnlockFlashTimer > 0) {
+      this.spinnerUnlockFlashTimer -= deltaTime;
+      if (this.spinnerUnlockFlashTimer <= 0) {
+        this.spinnerUnlockFlashTimer = 0;
+        this.redrawSpinnerIndicators();
+      }
+    }
   }
 
   resize(width: number, height: number): void {
@@ -389,6 +424,7 @@ export class DominosRenderer implements GameRenderer {
     this.sidebar?.destroy();
     this.sidebar = null;
     this.boardLayer.removeChildren();
+    this.spinnerIndicatorLayer.removeChildren();
     this.ghostLayer.removeChildren();
     this.handLayer.removeChildren();
     this.validEnds = [];
@@ -778,6 +814,7 @@ export class DominosRenderer implements GameRenderer {
   private redrawAll(): void {
     this.redrawBoardBackground();
     this.redrawBoard();
+    this.redrawSpinnerIndicators();
     this.drawGhostTiles();
     this.redrawHand();
     this.redrawBoneyard();
@@ -1003,6 +1040,130 @@ export class DominosRenderer implements GameRenderer {
     this.endPositions.b = { x: armBEndX + BOARD_TILE_GAP * scale, y: spinnerCY };
     this.endPositions.c = { x: spinnerCX, y: armCEndY - BOARD_TILE_GAP * scale };
     this.endPositions.d = { x: spinnerCX, y: armDEndY + BOARD_TILE_GAP * scale };
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Spinner arm indicators (C/D discoverability)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Draws subtle visual indicators above/below the spinner to hint that
+   * perpendicular arms (C up, D down) exist and whether they are locked or
+   * playable. Indicators hide once a tile has been placed on the arm.
+   */
+  private redrawSpinnerIndicators(): void {
+    for (const child of this.spinnerIndicatorLayer.removeChildren()) {
+      child.destroy();
+    }
+
+    if (this.layoutMode !== "cross" || this.spinnerTileId === -1) {
+      return;
+    }
+
+    const scale = this.boardScale;
+    const spinnerHalfH = (BOARD_TILE_W * scale) / 2;
+    const cx = this.crossSpinnerCX;
+    const cy = this.crossSpinnerCY;
+
+    const hasArmCTiles = this.boardTiles.some((t) => t.arm === "c");
+    const hasArmDTiles = this.boardTiles.some((t) => t.arm === "d");
+    const armCActive = this.openEndC >= 0;
+    const armDActive = this.openEndD >= 0;
+
+    // C indicator — extends UP from spinner
+    if (!hasArmCTiles) {
+      this.drawSpinnerArmIndicator(cx, cy - spinnerHalfH, -1, scale, armCActive, "C");
+    }
+
+    // D indicator — extends DOWN from spinner
+    if (!hasArmDTiles) {
+      this.drawSpinnerArmIndicator(cx, cy + spinnerHalfH, 1, scale, armDActive, "D");
+    }
+  }
+
+  private drawSpinnerArmIndicator(
+    x: number,
+    edgeY: number,
+    direction: 1 | -1,
+    scale: number,
+    isActive: boolean,
+    label: string,
+  ): void {
+    const g = new Graphics();
+    g.eventMode = "none";
+
+    const isFlashing = this.spinnerUnlockFlashTimer > 0 && isActive;
+
+    let color: number;
+    let alpha: number;
+    if (isFlashing) {
+      color = SPINNER_IND_FLASH_COLOR;
+      alpha = SPINNER_IND_FLASH_ALPHA;
+    } else if (isActive) {
+      color = SPINNER_IND_ACTIVE_COLOR;
+      alpha = SPINNER_IND_ACTIVE_ALPHA;
+    } else {
+      color = SPINNER_IND_LOCKED_COLOR;
+      alpha = SPINNER_IND_LOCKED_ALPHA;
+    }
+
+    const gap = 4 * scale;
+    const length = SPINNER_IND_LENGTH * scale;
+    const lineStartY = edgeY + direction * gap;
+    const lineEndY = lineStartY + direction * length;
+
+    if (isActive) {
+      // Solid line for active/unlocked arms
+      g.moveTo(x, lineStartY).lineTo(x, lineEndY).stroke({ color, alpha, width: 2 });
+    } else {
+      // Dashed line for locked arms
+      const dashLen = SPINNER_IND_DASH_LEN * scale;
+      const gapLen = SPINNER_IND_GAP_LEN * scale;
+      let pos = 0;
+      while (pos < length) {
+        const segEnd = Math.min(pos + dashLen, length);
+        g.moveTo(x, lineStartY + direction * pos)
+          .lineTo(x, lineStartY + direction * segEnd);
+        pos += dashLen + gapLen;
+      }
+      g.stroke({ color, alpha, width: 2 });
+    }
+
+    // Arrow tip (filled triangle) or locked circle at the end of the line
+    const arrowSize = SPINNER_IND_ARROW_SIZE * scale;
+    if (isActive) {
+      g.moveTo(x, lineEndY + direction * arrowSize)
+        .lineTo(x - arrowSize, lineEndY)
+        .lineTo(x + arrowSize, lineEndY)
+        .closePath()
+        .fill({ color, alpha });
+    } else {
+      g.circle(x, lineEndY + direction * (arrowSize * 0.5), 3 * scale)
+        .fill({ color, alpha });
+    }
+
+    // Glow ring during unlock flash
+    if (isFlashing) {
+      g.circle(x, lineEndY + direction * arrowSize, 8 * scale)
+        .fill({ color: SPINNER_IND_FLASH_COLOR, alpha: 0.25 });
+    }
+
+    // Arm label
+    const labelText = new Text({
+      text: label,
+      style: {
+        fontFamily: "sans-serif",
+        fontSize: Math.max(10, 11 * scale),
+        fontWeight: isActive ? "700" : "500",
+        fill: color,
+      },
+    });
+    labelText.alpha = alpha;
+    labelText.anchor.set(0.5);
+    labelText.position.set(x + 12 * scale, (lineStartY + lineEndY) / 2);
+    g.addChild(labelText);
+
+    this.spinnerIndicatorLayer.addChild(g);
   }
 
   // ── Arm dimension helpers ──────────────────────────────────────────────────

--- a/client/src/ui/SetupScreen.ts
+++ b/client/src/ui/SetupScreen.ts
@@ -488,7 +488,6 @@ function injectStyles(): void {
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: var(--space-md);
       border-radius: var(--radius-xl);
       border: 2px dashed rgba(255, 255, 255, 0.2);
       cursor: pointer;
@@ -504,7 +503,8 @@ function injectStyles(): void {
       color: var(--text-muted);
       font-size: var(--font-sm);
       cursor: pointer;
-      padding: 0;
+      padding: var(--space-md);
+      width: 100%;
       font-family: inherit;
       transition: color 0.15s;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eschaton/playgrid",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eschaton/playgrid",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "workspaces": [
         "client",
         "server",
@@ -27,7 +27,7 @@
     },
     "client": {
       "name": "@eschaton/playgrid-client",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@colyseus/sdk": "^0.17.26",
         "@eschaton/shared": "file:../shared",
@@ -11423,7 +11423,7 @@
     },
     "server": {
       "name": "@eschaton/playgrid-server",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@colyseus/core": "^0.17.32",
         "@colyseus/schema": "^4.0.19",
@@ -11594,7 +11594,7 @@
     },
     "shared": {
       "name": "@eschaton/shared",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@colyseus/schema": "^4.0.8",
         "colyseus": "^0.17.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid-server",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "scripts": {
     "dev": "node --watch --env-file-if-exists=../.env --import tsx src/index.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/shared",
   "private": true,
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

Three UX improvements from this session:

### 1. Fix button click hit areas
- **Problem:** 'Add CPU Player' button only responded to clicks on the text, not the full button area
- **Fix:** Moved padding from parent container to `<button>` elements, added `width: 100%`
- **Files:** `client/index.html`, `client/src/ui/SetupScreen.ts`

### 2. Fix browser back button lobby cleanup
- **Problem:** Navigating away (browser back, tab close, refresh) didn't disconnect from the lobby, causing stale room state
- **Fix:** Added `pagehide` event listener in Application.ts that calls `lobbyRoom.leave()`. Game room intentionally left open for reconnection. `isPageUnloading` guard prevents spurious reconnect attempts during teardown.
- **Files:** `client/src/Application.ts`

### 3. Domino spinner arm indicators
- **Problem:** Players couldn't tell that perpendicular arms (C/D) exist on the spinner, or when they become available
- **Fix:** Added PixiJS visual indicators:
  - **Locked state:** Dashed gray lines extending up/down from spinner
  - **Unlock moment:** 1.5s bright flash with glow effect
  - **Active state:** Solid blue arrows matching existing end marker style
  - **Auto-hide:** Indicators disappear once a tile is placed on that arm
- **Files:** `client/src/renderers/DominosRenderer.ts`

### Issues Filed
- #176 — Support multiple CPU players in multi-player games (architectural)
- #177 — Add placement animations for game pieces

### Validation
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test` ✅ (803 tests passing)