### PR TITLE
fix: backgammon dice visibility and roll animation speed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid-client",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/client/src/renderers/BackgammonRenderer.ts
+++ b/client/src/renderers/BackgammonRenderer.ts
@@ -412,7 +412,7 @@ export class BackgammonRenderer implements GameRenderer {
   private isRollingDice = false;
   private movePending = false;
   private rollAnimationFrame = 0;
-  private rollAnimationDuration = 20;
+  private rollAnimationDuration = 40;
 
   constructor() {
     this.piecesLayer.eventMode = "none";
@@ -482,7 +482,6 @@ export class BackgammonRenderer implements GameRenderer {
       this.barBottomArea,
       this.offTopArea,
       this.offBottomArea,
-      this.diceLayer,
     );
 
     this.container.addChild(
@@ -490,6 +489,7 @@ export class BackgammonRenderer implements GameRenderer {
       this.playerColorText,
       this.boardLayer,
       this.piecesLayer,
+      this.diceLayer,
       this.blackOffText,
       this.redOffText,
       this.overlayLayer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eschaton/playgrid",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eschaton/playgrid",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "workspaces": [
         "client",
         "server",
@@ -27,7 +27,7 @@
     },
     "client": {
       "name": "@eschaton/playgrid-client",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@colyseus/sdk": "^0.17.26",
         "@eschaton/shared": "file:../shared",
@@ -11423,7 +11423,7 @@
     },
     "server": {
       "name": "@eschaton/playgrid-server",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@colyseus/core": "^0.17.32",
         "@colyseus/schema": "^4.0.19",
@@ -11594,7 +11594,7 @@
     },
     "shared": {
       "name": "@eschaton/shared",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@colyseus/schema": "^4.0.8",
         "colyseus": "^0.17.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/playgrid-server",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "scripts": {
     "dev": "node --watch --env-file-if-exists=../.env --import tsx src/index.ts",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eschaton/shared",
   "private": true,
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

Two backgammon UX fixes:

### 1. Dice obscured by bar pieces
- **Problem:** Pieces sitting on the bar visually covered the dice, making rolls hard to read
- **Fix:** Moved `diceLayer` from `boardLayer` to the main `container` after `piecesLayer`, so dice always render above bar pieces
- **File:** `client/src/renderers/BackgammonRenderer.ts`

### 2. Dice roll animation too fast
- **Problem:** Roll animation was too quick to register
- **Fix:** Doubled `rollAnimationDuration` from 20 → 40 frames
- **File:** `client/src/renderers/BackgammonRenderer.ts`

### Validation
- `npm run build` ✅
- `npm run lint` ✅
- `npm run test` ✅ (803 tests passing)