### PR TITLE
feat: reusable turn timer system

### DIFF
--- a/.squad/agents/pemulis/history.md
+++ b/.squad/agents/pemulis/history.md
@@ -1521,3 +1521,16 @@ Investigation confirmed Dominos CPU opponent support was already fully implement
 
 **Validation:** Build ✓, Lint ✓, 799 tests passing (Steeply's new tests included). Issue #163 closed.
 
+
+### Reusable turn timer system (2026-03-19, refs #148)
+
+- **Problem:** Turn timeouts immediately ended the game with a loss — terrible UX for casual/multiplayer games like Risk.
+- **Design:** Standalone `TurnTimer` class in `server/src/game/TurnTimer.ts` with Colyseus clock integration. Per-turn countdown that resets on valid action or turn change. Escalating penalties: timeouts 1..(N-1) → warning + reset, timeout N → configurable final action (auto-pass or forfeit).
+- **Configuration:** New `TurnTimerConfiguration` interface on `GamePlugin`. Each game opts in with `turnTimerConfig: { enabled, turnDurationMs, warningThresholdMs, maxTimeouts, finalTimeoutAction }`.
+- **State sync:** `BaseGameState.turnTimeRemaining`, `timerWarningActive`, and new `turnTimeoutCount` sync to clients for countdown UI and escalation display.
+- **Integration points:** `BaseGameRoom` creates `TurnTimer` in `onCreate`, starts on turn begin, resets on valid action, pauses on disconnect, resumes on reconnect, stops on game end.
+- **Risk wiring:** 120s turns, 15s warning threshold, 3 timeouts before auto-pass. Coexists with chess clock (total time bank).
+- **Parallel to chess clock:** Turn timer is per-turn with graceful escalation (casual). Chess clock is cumulative time bank (competitive). Both can be active simultaneously.
+- **Key files:** `server/src/game/TurnTimer.ts`, `shared/src/gamePlugin.ts` (TurnTimerConfiguration), `shared/src/BaseGameState.ts` (turnTimeoutCount), `server/src/game/BaseGameRoom.ts` (integration), `server/src/games/risk/RiskPlugin.ts` (proof of concept).
+- **Tests:** 22 new unit tests in `server/src/__tests__/TurnTimer.test.ts` covering lifecycle, warning threshold, escalation, pause/resume, dispose.
+- **Validation:** Build ✓, Lint ✓, 825 tests passing.

--- a/.squad/decisions/inbox/pemulis-turn-timer.md
+++ b/.squad/decisions/inbox/pemulis-turn-timer.md
@@ -1,0 +1,46 @@
+### Pemulis: Reusable Turn Timer System
+
+**Status:** Implemented
+**Date:** 2026-03-19
+**PR:** (pending — squad/148-turn-timer)
+**Issue:** #148
+
+Implemented a reusable per-turn timer with escalating penalties for all turn-based games.
+
+**Architecture:**
+- **Module:** Standalone `TurnTimer` class using Colyseus `clock.setInterval` (NOT setTimeout/setInterval)
+- **Configuration:** New `TurnTimerConfiguration` interface on `GamePlugin` — each game opts in independently
+- **State sync:** `turnTimeRemaining`, `timerWarningActive`, `turnTimeoutCount` on `BaseGameState` for client countdown UI
+- **Escalation:** Timeouts 1..(maxTimeouts-1) → warning + timer reset; timeout at maxTimeouts → auto-pass or forfeit (configurable)
+- **Integration:** BaseGameRoom creates/starts/resets/pauses/resumes/stops the timer at each turn lifecycle point
+
+**Rationale:**
+- Previous behavior: chess clock timeout → immediate game loss. Unacceptable UX for casual multiplayer (Risk, Dominos).
+- Turn timer is complementary to chess clock: per-turn countdown with grace periods vs. cumulative time bank.
+- Standalone class keeps BaseGameRoom from growing further, mirrors TurnManager pattern.
+- Colyseus clock ensures proper server-side timing without setTimeout drift.
+- Escalating penalties give players fair warning before consequences.
+
+**Alternatives Considered:**
+- Inline in BaseGameRoom — Rejected: would bloat the room class, harder to test in isolation
+- Modify chess clock to add per-turn limits — Rejected: different concerns (cumulative vs per-turn)
+- Client-side timers — Rejected: must be server-authoritative per project conventions
+
+**Risk wiring (proof of concept):**
+- 120s per turn, 15s warning threshold, 3 timeouts → auto-pass
+- Coexists with existing chess clock (total time bank)
+
+**Impact:**
+- Any turn-based game can add `turnTimerConfig` to opt in
+- Clients can read `turnTimeRemaining` / `timerWarningActive` / `turnTimeoutCount` for UI
+- `turn-timer-warning` message broadcast for client-side notification display
+- No breaking changes — fully optional, backward compatible
+
+**Files:**
+- `server/src/game/TurnTimer.ts` (new module)
+- `server/src/__tests__/TurnTimer.test.ts` (22 new tests)
+- `shared/src/gamePlugin.ts` (TurnTimerConfiguration interface)
+- `shared/src/BaseGameState.ts` (turnTimeoutCount field)
+- `shared/src/index.ts` (export)
+- `server/src/game/BaseGameRoom.ts` (integration)
+- `server/src/games/risk/RiskPlugin.ts` (proof of concept wiring)

--- a/server/src/__tests__/TurnTimer.test.ts
+++ b/server/src/__tests__/TurnTimer.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Delayed } from "@colyseus/timer";
+import type { TurnTimerConfiguration } from "@eschaton/shared";
+import { TurnTimer, type TurnTimerCallbacks } from "../game/TurnTimer.js";
+
+function createMockClock() {
+  return {
+    setTimeout(callback: (...args: unknown[]) => void, delayMs: number): Delayed {
+      const id = setTimeout(callback, delayMs);
+      return { clear: () => clearTimeout(id) } as Delayed;
+    },
+    setInterval(callback: (...args: unknown[]) => void, delayMs: number): Delayed {
+      const id = setInterval(callback, delayMs);
+      return { clear: () => clearInterval(id) } as Delayed;
+    },
+  };
+}
+
+function createConfig(overrides: Partial<TurnTimerConfiguration> = {}): TurnTimerConfiguration {
+  return {
+    enabled: true,
+    turnDurationMs: 30_000,
+    warningThresholdMs: 10_000,
+    maxTimeouts: 3,
+    finalTimeoutAction: "auto-pass",
+    ...overrides,
+  };
+}
+
+function createCallbacks(): TurnTimerCallbacks & {
+  onWarning: ReturnType<typeof vi.fn>;
+  onTimeout: ReturnType<typeof vi.fn>;
+  onTick: ReturnType<typeof vi.fn>;
+} {
+  return {
+    onWarning: vi.fn(),
+    onTimeout: vi.fn(),
+    onTick: vi.fn(),
+  };
+}
+
+describe("TurnTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("basic lifecycle", () => {
+    it("starts with full duration and syncs state", () => {
+      const config = createConfig({ turnDurationMs: 60_000 });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+
+      expect(callbacks.onTick).toHaveBeenCalledWith(60_000, false);
+      expect(timer.isRunning()).toBe(true);
+    });
+
+    it("counts down over time", () => {
+      const config = createConfig({ turnDurationMs: 30_000, warningThresholdMs: 5_000 });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      callbacks.onTick.mockClear();
+
+      vi.advanceTimersByTime(1_000);
+
+      // Should have ticked ~5 times (200ms intervals over 1s)
+      const lastCall = callbacks.onTick.mock.calls.at(-1);
+      expect(lastCall).toBeDefined();
+      expect(lastCall![0]).toBeLessThanOrEqual(29_200);
+      expect(lastCall![0]).toBeGreaterThanOrEqual(28_800);
+      expect(lastCall![1]).toBe(false); // not in warning zone yet
+    });
+
+    it("stops cleanly", () => {
+      const config = createConfig();
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      timer.stop();
+
+      expect(timer.isRunning()).toBe(false);
+      callbacks.onTick.mockClear();
+
+      vi.advanceTimersByTime(5_000);
+      expect(callbacks.onTick).not.toHaveBeenCalled();
+    });
+
+    it("resets timer to full duration", () => {
+      const config = createConfig({ turnDurationMs: 30_000 });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(10_000);
+
+      callbacks.onTick.mockClear();
+      timer.reset();
+
+      expect(callbacks.onTick).toHaveBeenCalledWith(30_000, false);
+    });
+
+    it("does nothing on reset when not running", () => {
+      const config = createConfig();
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.reset();
+      expect(callbacks.onTick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("warning threshold", () => {
+    it("fires warning when crossing threshold", () => {
+      const config = createConfig({
+        turnDurationMs: 15_000,
+        warningThresholdMs: 10_000,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onWarning).toHaveBeenCalledWith("player-1", 0);
+    });
+
+    it("sets warningActive in tick when in warning zone", () => {
+      const config = createConfig({
+        turnDurationMs: 15_000,
+        warningThresholdMs: 10_000,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(6_000);
+
+      const lastCall = callbacks.onTick.mock.calls.at(-1);
+      expect(lastCall![1]).toBe(true); // warningActive
+    });
+
+    it("fires warning only once per timer cycle", () => {
+      const config = createConfig({
+        turnDurationMs: 15_000,
+        warningThresholdMs: 10_000,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(10_000);
+
+      expect(callbacks.onWarning).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets warning state after timer reset", () => {
+      const config = createConfig({
+        turnDurationMs: 15_000,
+        warningThresholdMs: 10_000,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(6_000);
+      expect(callbacks.onWarning).toHaveBeenCalledTimes(1);
+
+      timer.reset();
+      callbacks.onWarning.mockClear();
+
+      vi.advanceTimersByTime(6_000);
+      expect(callbacks.onWarning).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("timeout escalation", () => {
+    it("resets timer on first timeout (non-final)", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onTimeout).toHaveBeenCalledWith("player-1", 1, false);
+      expect(timer.isRunning()).toBe(true);
+      expect(timer.getTimeoutCount("player-1")).toBe(1);
+    });
+
+    it("resets timer on second timeout (non-final)", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onTimeout).toHaveBeenCalledTimes(2);
+      expect(callbacks.onTimeout).toHaveBeenCalledWith("player-1", 2, false);
+      expect(timer.isRunning()).toBe(true);
+    });
+
+    it("stops on final timeout", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+      vi.advanceTimersByTime(5_200);
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onTimeout).toHaveBeenCalledTimes(3);
+      expect(callbacks.onTimeout).toHaveBeenLastCalledWith("player-1", 3, true);
+      expect(timer.isRunning()).toBe(false);
+    });
+
+    it("tracks timeout counts per player independently", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      // Player 1 times out once
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      // Switch to player 2
+      timer.start("player-2");
+      vi.advanceTimersByTime(5_200);
+
+      expect(timer.getTimeoutCount("player-1")).toBe(1);
+      expect(timer.getTimeoutCount("player-2")).toBe(1);
+    });
+
+    it("accumulates timeouts across turns for the same player", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      // Player 1 times out once on their turn
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+      expect(timer.getTimeoutCount("player-1")).toBe(1);
+
+      // Player 2 takes their turn (no timeout)
+      timer.start("player-2");
+      vi.advanceTimersByTime(2_000);
+
+      // Back to player 1, they time out again
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+      expect(timer.getTimeoutCount("player-1")).toBe(2);
+    });
+
+    it("triggers final timeout on third timeout for accumulated player", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 3,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      // P1 timeout #1
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      // P2 turn (no timeout)
+      timer.start("player-2");
+      vi.advanceTimersByTime(2_000);
+
+      // P1 timeout #2
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      // P2 turn again
+      timer.start("player-2");
+      vi.advanceTimersByTime(2_000);
+
+      // P1 timeout #3 (final)
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onTimeout).toHaveBeenLastCalledWith("player-1", 3, true);
+      expect(timer.isRunning()).toBe(false);
+    });
+
+    it("works with maxTimeouts of 1 (immediate final)", () => {
+      const config = createConfig({
+        turnDurationMs: 5_000,
+        warningThresholdMs: 1_000,
+        maxTimeouts: 1,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+
+      expect(callbacks.onTimeout).toHaveBeenCalledWith("player-1", 1, true);
+      expect(timer.isRunning()).toBe(false);
+    });
+  });
+
+  describe("pause and resume", () => {
+    it("pauses countdown", () => {
+      const config = createConfig({ turnDurationMs: 30_000 });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_000);
+
+      const lastRemainingBeforePause = callbacks.onTick.mock.calls.at(-1)![0] as number;
+
+      timer.pause();
+      callbacks.onTick.mockClear();
+
+      vi.advanceTimersByTime(10_000);
+
+      // Ticks still fire (interval runs) but remaining doesn't change
+      for (const call of callbacks.onTick.mock.calls) {
+        expect(call[0]).toBe(lastRemainingBeforePause);
+      }
+    });
+
+    it("resumes from paused state", () => {
+      const config = createConfig({
+        turnDurationMs: 30_000,
+        warningThresholdMs: 5_000,
+      });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(10_000);
+      timer.pause();
+      vi.advanceTimersByTime(60_000); // long pause
+
+      timer.resume();
+      callbacks.onTick.mockClear();
+
+      vi.advanceTimersByTime(1_000);
+
+      // Should resume counting down from where it paused
+      const lastCall = callbacks.onTick.mock.calls.at(-1);
+      expect(lastCall).toBeDefined();
+      expect(lastCall![0]).toBeLessThan(20_200);
+      expect(lastCall![0]).toBeGreaterThan(18_000);
+    });
+
+    it("ignores pause when not running", () => {
+      const config = createConfig();
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.pause(); // no-op
+      expect(timer.isRunning()).toBe(false);
+    });
+
+    it("ignores resume when not paused", () => {
+      const config = createConfig();
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      timer.resume(); // no-op, already running
+      expect(timer.isRunning()).toBe(true);
+    });
+  });
+
+  describe("dispose", () => {
+    it("stops the timer and clears timeout counts", () => {
+      const config = createConfig({ turnDurationMs: 5_000 });
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+      timer.setClock(createMockClock());
+
+      timer.start("player-1");
+      vi.advanceTimersByTime(5_200);
+      expect(timer.getTimeoutCount("player-1")).toBe(1);
+
+      timer.dispose();
+
+      expect(timer.isRunning()).toBe(false);
+      expect(timer.getTimeoutCount("player-1")).toBe(0);
+    });
+  });
+
+  describe("no clock", () => {
+    it("does not start interval without a clock", () => {
+      const config = createConfig();
+      const callbacks = createCallbacks();
+      const timer = new TurnTimer(config, callbacks);
+
+      timer.start("player-1");
+
+      // Initial onTick is called, but no interval ticks
+      expect(callbacks.onTick).toHaveBeenCalledTimes(1);
+      expect(timer.isRunning()).toBe(true);
+
+      vi.advanceTimersByTime(5_000);
+      expect(callbacks.onTick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/server/src/game/BaseGameRoom.ts
+++ b/server/src/game/BaseGameRoom.ts
@@ -23,6 +23,7 @@ import { GAME_ROOM_DISPOSED_TOPIC } from "../rooms/lobbyPresence.js";
 import { trackEvent } from "../telemetry.js";
 import { gameRegistry } from "./GameRegistry.js";
 import { TurnManager } from "./TurnManager.js";
+import { TurnTimer } from "./TurnTimer.js";
 
 interface BaseGameRoomOptions extends GameOptions {
   cpuOpponent?: boolean;
@@ -51,6 +52,7 @@ export class BaseGameRoom extends Room {
 
   private plugin!: GamePlugin<BaseGameState>;
   private turnManager?: TurnManager;
+  private turnTimer?: TurnTimer;
   private expectedPlayers = 0;
   private reconnectionTimeout = DEFAULT_RECONNECTION_TIMEOUT;
   private gameId?: string;
@@ -124,6 +126,28 @@ export class BaseGameRoom extends Room {
       });
     }
 
+    // Turn timer with escalating penalties (disabled for CPU games)
+    if (this.plugin.turnTimerConfig?.enabled && !this.cpuOpponentEnabled) {
+      this.turnTimer = new TurnTimer(this.plugin.turnTimerConfig, {
+        onWarning: (_sessionId, _timeoutCount) => {
+          // Warning state is synced to clients via onTick callback
+        },
+        onTimeout: (sessionId, timeoutCount, isFinal) => {
+          void this.handleTurnTimerTimeout(sessionId, timeoutCount, isFinal);
+        },
+        onTick: (remainingMs, warningActive) => {
+          this.state.turnTimeRemaining = remainingMs;
+          this.state.timerWarningActive = warningActive;
+          this.state.turnTimeoutCount = this.turnTimer?.getTimeoutCount(
+            this.state.currentTurn,
+          ) ?? 0;
+        },
+      });
+      if (this.clock) {
+        this.turnTimer.setClock(this.clock);
+      }
+    }
+
     try {
       const pool = getPool();
       this.gameId = await gameRepository.createGame(pool, {
@@ -150,6 +174,9 @@ export class BaseGameRoom extends Room {
       if (wasDisconnected) {
         this.plugin.lifecycle.onPlayerReconnect?.(this.state, client);
         this.sendPlayerMessage(client);
+        if (this.isTurnControlledBy(client.sessionId)) {
+          this.resumeTurnTimerFor(client.sessionId);
+        }
         trackEvent("player_reconnected", {
           gameType: this.plugin.name,
           roomId: this.roomId,
@@ -225,6 +252,9 @@ export class BaseGameRoom extends Room {
       && !player.isSpectator
       && code !== CloseCode.CONSENTED
     ) {
+      if (this.isTurnControlledBy(client.sessionId)) {
+        this.pauseTurnTimerFor(client.sessionId);
+      }
       try {
         await this.allowReconnection(client, this.reconnectionTimeout);
         player.isConnected = true;
@@ -297,6 +327,7 @@ export class BaseGameRoom extends Room {
   override onDispose() {
     this.cancelPendingCpuTurn();
     this.turnManager?.stop();
+    this.turnTimer?.dispose();
 
     if (this.lobbyGameId) {
       this.presence.publish(GAME_ROOM_DISPOSED_TOPIC, {
@@ -379,6 +410,7 @@ export class BaseGameRoom extends Room {
     }
 
     this.recordMove(actionType, actingClient.sessionId, recordPayload);
+    this.resetTurnTimer();
 
     this.broadcastPlayerMessages();
 
@@ -449,6 +481,7 @@ export class BaseGameRoom extends Room {
     this.state.currentTurn = this.turnManager.getCurrentPlayer();
     this.state.turnNumber = this.turnManager.getTurnNumber();
     this.broadcastPlayerMessages();
+    this.startTurnTimer();
     this.queueCpuTurnIfNeeded();
     trackEvent("game_started", {
       gameType: this.plugin.name,
@@ -467,6 +500,7 @@ export class BaseGameRoom extends Room {
     this.state.turnNumber = this.turnManager.getTurnNumber();
 
     this.plugin.lifecycle.onTurnStarted?.(this.state, this.state.currentTurn);
+    this.startTurnTimer();
     this.queueCpuTurnIfNeeded();
   }
 
@@ -528,6 +562,7 @@ export class BaseGameRoom extends Room {
 
     this.cancelPendingCpuTurn();
     this.turnManager?.stop();
+    this.turnTimer?.stop();
     this.state.phase = "ended";
     this.state.currentTurn = "";
 
@@ -867,11 +902,11 @@ export class BaseGameRoom extends Room {
   }
 
   private pauseTurnTimerFor(_sessionId: string) {
-    // Turn timers removed — chess clocks handle timing now.
+    this.turnTimer?.pause();
   }
 
   private resumeTurnTimerFor(_sessionId: string) {
-    // Turn timers removed — chess clocks handle timing now.
+    this.turnTimer?.resume();
   }
 
   private isTurnControlledBy(sessionId: string) {
@@ -900,6 +935,58 @@ export class BaseGameRoom extends Room {
 
   private updateTurnTimeRemaining() {
     this.state.turnTimeRemaining = 0;
+  }
+
+  private startTurnTimer() {
+    if (!this.turnTimer || this.isCpuTurn(this.state.currentTurn)) {
+      return;
+    }
+
+    this.turnTimer.start(this.state.currentTurn);
+  }
+
+  private resetTurnTimer() {
+    this.turnTimer?.reset();
+  }
+
+  private async handleTurnTimerTimeout(
+    sessionId: string,
+    timeoutCount: number,
+    isFinal: boolean,
+  ) {
+    if (this.state.phase === "ended") {
+      return;
+    }
+
+    const config = this.plugin.turnTimerConfig;
+    if (!config) {
+      return;
+    }
+
+    if (!isFinal) {
+      // Non-final timeout: broadcast a warning to all clients
+      this.broadcast("turn-timer-warning", {
+        sessionId,
+        timeoutCount,
+        maxTimeouts: config.maxTimeouts,
+      });
+      return;
+    }
+
+    // Final timeout: execute the configured penalty
+    if (config.finalTimeoutAction === "auto-pass") {
+      this.broadcast("turn-timer-warning", {
+        sessionId,
+        timeoutCount,
+        maxTimeouts: config.maxTimeouts,
+        action: "auto-pass",
+      });
+      this.advanceTurn();
+      return;
+    }
+
+    // Forfeit
+    await this.handleTurnTimeout(sessionId);
   }
 
   private orderTurnPlayers(playerIds: string[]) {

--- a/server/src/game/TurnTimer.ts
+++ b/server/src/game/TurnTimer.ts
@@ -1,0 +1,178 @@
+import type { Delayed } from "@colyseus/timer";
+import type { TurnTimerConfiguration } from "@eschaton/shared";
+
+export interface TurnTimerCallbacks {
+  /** Called when the warning threshold is crossed */
+  onWarning(sessionId: string, timeoutCount: number): void;
+  /** Called when the turn timer expires */
+  onTimeout(sessionId: string, timeoutCount: number, isFinal: boolean): void;
+  /** Update synced state: remaining time and warning flag */
+  onTick(remainingMs: number, warningActive: boolean): void;
+}
+
+interface ClockLike {
+  setInterval(callback: (...args: unknown[]) => void, delayMs: number): Delayed;
+}
+
+const TICK_INTERVAL_MS = 200;
+
+/**
+ * Reusable per-turn countdown timer with escalating penalties.
+ *
+ * Designed to plug into any turn-based game via BaseGameRoom.
+ * Uses the Colyseus clock (no setTimeout/setInterval) and syncs
+ * remaining time to shared state so clients can render a countdown.
+ *
+ * Escalation:
+ *   timeouts 1..(maxTimeouts-1) → warning + timer reset
+ *   timeout at maxTimeouts       → final action (auto-pass or forfeit)
+ */
+export class TurnTimer {
+  private readonly config: TurnTimerConfiguration;
+  private readonly callbacks: TurnTimerCallbacks;
+
+  private remainingMs = 0;
+  private running = false;
+  private paused = false;
+  private warningFired = false;
+  private currentSessionId = "";
+  private tickInterval?: Delayed;
+  private clock?: ClockLike;
+
+  /** Tracks cumulative timeout count per player across the game */
+  private readonly timeoutCounts = new Map<string, number>();
+
+  constructor(config: TurnTimerConfiguration, callbacks: TurnTimerCallbacks) {
+    this.config = config;
+    this.callbacks = callbacks;
+  }
+
+  /** Attach a Colyseus clock. Must be called before start(). */
+  setClock(clock: ClockLike): void {
+    this.clock = clock;
+  }
+
+  /** Start (or restart) the timer for the given player's turn. */
+  start(sessionId: string): void {
+    this.stop();
+    this.currentSessionId = sessionId;
+    this.remainingMs = this.config.turnDurationMs;
+    this.warningFired = false;
+    this.running = true;
+    this.paused = false;
+
+    this.callbacks.onTick(this.remainingMs, false);
+    this.startTickInterval();
+  }
+
+  /** Reset the timer (e.g. after a valid action during the same turn). */
+  reset(): void {
+    if (!this.running) {
+      return;
+    }
+
+    this.remainingMs = this.config.turnDurationMs;
+    this.warningFired = false;
+    this.paused = false;
+
+    this.callbacks.onTick(this.remainingMs, false);
+  }
+
+  /** Pause the countdown (e.g. player disconnected). */
+  pause(): void {
+    if (!this.running || this.paused) {
+      return;
+    }
+
+    this.paused = true;
+  }
+
+  /** Resume after a pause (e.g. player reconnected). */
+  resume(): void {
+    if (!this.running || !this.paused) {
+      return;
+    }
+
+    this.paused = false;
+  }
+
+  /** Fully stop the timer and clear intervals. */
+  stop(): void {
+    this.running = false;
+    this.paused = false;
+    this.tickInterval?.clear();
+    this.tickInterval = undefined;
+  }
+
+  /** Get the timeout count for a specific player. */
+  getTimeoutCount(sessionId: string): number {
+    return this.timeoutCounts.get(sessionId) ?? 0;
+  }
+
+  /** Check whether the timer is actively running. */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /** Dispose of all resources. */
+  dispose(): void {
+    this.stop();
+    this.timeoutCounts.clear();
+  }
+
+  private startTickInterval(): void {
+    this.tickInterval?.clear();
+
+    if (!this.clock) {
+      return;
+    }
+
+    this.tickInterval = this.clock.setInterval(() => {
+      this.tick(TICK_INTERVAL_MS);
+    }, TICK_INTERVAL_MS);
+  }
+
+  private tick(deltaMs: number): void {
+    if (!this.running || this.paused) {
+      return;
+    }
+
+    this.remainingMs = Math.max(0, this.remainingMs - deltaMs);
+
+    const warningActive = this.remainingMs <= this.config.warningThresholdMs
+      && this.remainingMs > 0;
+
+    if (warningActive && !this.warningFired) {
+      this.warningFired = true;
+      this.callbacks.onWarning(
+        this.currentSessionId,
+        this.getTimeoutCount(this.currentSessionId),
+      );
+    }
+
+    this.callbacks.onTick(this.remainingMs, warningActive);
+
+    if (this.remainingMs <= 0) {
+      this.handleTimeout();
+    }
+  }
+
+  private handleTimeout(): void {
+    const sessionId = this.currentSessionId;
+    const count = (this.timeoutCounts.get(sessionId) ?? 0) + 1;
+    this.timeoutCounts.set(sessionId, count);
+
+    const isFinal = count >= this.config.maxTimeouts;
+
+    if (!isFinal) {
+      // Not final: reset timer for another chance
+      this.remainingMs = this.config.turnDurationMs;
+      this.warningFired = false;
+      this.callbacks.onTick(this.remainingMs, false);
+    } else {
+      this.stop();
+    }
+
+    this.callbacks.onTimeout(sessionId, count, isFinal);
+  }
+}

--- a/server/src/games/risk/RiskPlugin.ts
+++ b/server/src/games/risk/RiskPlugin.ts
@@ -271,6 +271,13 @@ export const riskPlugin: GamePlugin<RiskState> = {
     enabled: true,
     initialTimeBankMs: 600_000,
   },
+  turnTimerConfig: {
+    enabled: true,
+    turnDurationMs: 120_000,
+    warningThresholdMs: 15_000,
+    maxTimeouts: 3,
+    finalTimeoutAction: "auto-pass",
+  },
   lifecycle: {
     onPlayerJoin(state, client, playerIndex) {
       const existingPlayer = state.players.get(client.sessionId);

--- a/shared/src/BaseGameState.ts
+++ b/shared/src/BaseGameState.ts
@@ -34,6 +34,7 @@ export class BaseGameState extends Schema {
   declare players: MapSchema<PlayerInfo>;
   declare turnTimeRemaining: number;
   declare timerWarningActive: boolean;
+  declare turnTimeoutCount: number;
   declare player1TimeRemainingMs: number;
   declare player2TimeRemainingMs: number;
 
@@ -45,6 +46,7 @@ export class BaseGameState extends Schema {
     this.players = new MapSchema<PlayerInfo>();
     this.turnTimeRemaining = 0;
     this.timerWarningActive = false;
+    this.turnTimeoutCount = 0;
     this.player1TimeRemainingMs = 0;
     this.player2TimeRemainingMs = 0;
   }
@@ -56,6 +58,7 @@ defineTypes(BaseGameState, {
   players: { map: PlayerInfo },
   turnTimeRemaining: "number",
   timerWarningActive: "boolean",
+  turnTimeoutCount: "number",
   player1TimeRemainingMs: "number",
   player2TimeRemainingMs: "number",
 });

--- a/shared/src/gamePlugin.ts
+++ b/shared/src/gamePlugin.ts
@@ -28,6 +28,9 @@ export interface GamePlugin<TState extends Schema = Schema> {
   /** Chess clock configuration (optional) */
   chessClockConfig?: ChessClockConfiguration;
 
+  /** Turn timer configuration with escalating penalties (optional) */
+  turnTimerConfig?: TurnTimerConfiguration;
+
   /** Action handlers for player moves */
   actions: GameActionHandlers<TState>;
 
@@ -161,6 +164,28 @@ export interface ChessClockConfiguration {
 
   /** Initial time bank for each player in milliseconds */
   initialTimeBankMs: number;
+}
+
+/**
+ * Turn timer with escalating penalties.
+ * Per-turn countdown that resets on action or turn change.
+ * Timeouts escalate: warning → final warning → auto-pass or forfeit.
+ */
+export interface TurnTimerConfiguration {
+  /** Whether the turn timer is enabled */
+  enabled: boolean;
+
+  /** Duration of each turn in milliseconds */
+  turnDurationMs: number;
+
+  /** Time remaining (ms) at which to activate warning state */
+  warningThresholdMs: number;
+
+  /** Number of timeouts before the final penalty triggers */
+  maxTimeouts: number;
+
+  /** What happens when a player exhausts all timeout allowances */
+  finalTimeoutAction: "auto-pass" | "forfeit";
 }
 
 export type TurnOrderStrategy =

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -57,6 +57,7 @@ export type {
   TurnMode,
   TurnOrderStrategy,
   TurnPhase,
+  TurnTimerConfiguration,
 } from "./gamePlugin.js";
 export * from "./games/checkers/index.js";
 export { BackgammonState } from "./games/backgammon/index.js";


### PR DESCRIPTION
## Turn Timer System (refs #148)

Replaces the immediate-forfeit turn timeout behavior with a reusable escalating penalty system for all turn-based games.

### Problem
When a player ran out of time in Risk, the game immediately ended with a loss. Terrible UX.

### Solution
New `TurnTimer` module with:
- **Per-turn countdown** using Colyseus `clock` (not setTimeout)
- **Escalating penalties**: warning → final warning → auto-pass or forfeit (configurable)
- **State synced to clients**: `turnTimeRemaining`, `timerWarningActive`, `turnTimeoutCount`
- **Pause/resume** on disconnect/reconnect
- **Per-game configuration** via `turnTimerConfig` on the plugin interface

### Risk wiring (proof of concept)
120s per turn, 15s warning threshold, 3 timeouts before auto-pass. Coexists with chess clock.

### Files changed
- `server/src/game/TurnTimer.ts` — new reusable module
- `shared/src/gamePlugin.ts` — `TurnTimerConfiguration` interface
- `shared/src/BaseGameState.ts` — `turnTimeoutCount` field
- `server/src/game/BaseGameRoom.ts` — lifecycle integration
- `server/src/games/risk/RiskPlugin.ts` — proof of concept
- `server/src/__tests__/TurnTimer.test.ts` — 22 new tests

### Validation
✅ Build clean, ✅ Lint clean, ✅ 825 tests passing (22 new)