### PR TITLE
feat: add placement animations for game pieces (refs #177)

### DIFF
--- a/client/src/renderers/BackgammonRenderer.ts
+++ b/client/src/renderers/BackgammonRenderer.ts
@@ -7,6 +7,7 @@ import {
 } from "@eschaton/shared";
 import { Container, Graphics, Text } from "pixi.js";
 import { GameSidebar, escapeHtml, getTurnClockMarkup } from "../ui/GameSidebar";
+import { TweenManager } from "./TweenManager";
 import {
   ACCENT_BLUE,
   BACKGAMMON_OVERLAY_ALPHA,
@@ -59,6 +60,7 @@ const GAME_ENDED_MESSAGE = "game-end";
 const MAX_VISIBLE_STACK = 5;
 const MAX_SIDEBAR_HISTORY_ITEMS = 8;
 const EMPTY_POINT = 0;
+const PIECE_ANIM_DURATION_MS = 250;
 
 type BackgammonColor = typeof BLACK | typeof RED;
 type BackgammonSource = number | "bar";
@@ -414,6 +416,13 @@ export class BackgammonRenderer implements GameRenderer {
   private rollAnimationFrame = 0;
   private rollAnimationDuration = 40;
 
+  // Piece movement animation
+  private readonly animLayer = new Container();
+  private readonly tweens = new TweenManager();
+  private prevPoints: number[] = Array.from({ length: BOARD_POINT_COUNT }, () => EMPTY_POINT);
+  private prevBlackBar = 0;
+  private prevRedBar = 0;
+
   constructor() {
     this.piecesLayer.eventMode = "none";
     this.diceLayer.eventMode = "static";
@@ -489,6 +498,7 @@ export class BackgammonRenderer implements GameRenderer {
       this.playerColorText,
       this.boardLayer,
       this.piecesLayer,
+      this.animLayer,
       this.diceLayer,
       this.blackOffText,
       this.redOffText,
@@ -507,6 +517,7 @@ export class BackgammonRenderer implements GameRenderer {
     this.moveHistory = [];
     this.turnClockSeconds = null;
     this.showTurnClock = false;
+    this.tweens.cancelAll();
     this.sidebar?.destroy();
     this.sidebar = new GameSidebar();
     this.sidebar.addPanel("game-info", "Game Info");
@@ -515,6 +526,7 @@ export class BackgammonRenderer implements GameRenderer {
     this.sidebar.show();
     this.subscribeToRoomEvents();
     this.applyState(state);
+    this.snapshotBoardState();
     this.layout();
     this.redrawBoard();
     this.redrawPieces();
@@ -525,16 +537,27 @@ export class BackgammonRenderer implements GameRenderer {
 
   onStateChange(state: unknown): void {
     this.movePending = false;
+
+    // Snapshot previous state for animation detection
+    const oldPoints = this.prevPoints;
+    const oldBlackBar = this.prevBlackBar;
+    const oldRedBar = this.prevRedBar;
+
     this.applyState(state);
+    this.snapshotBoardState();
     this.syncSelectionWithState();
     this.redrawBoard();
     this.redrawPieces();
     this.updateHud();
     this.updateGameOverOverlay();
     this.updateSidebar();
+
+    this.animatePieceMovement(oldPoints, oldBlackBar, oldRedBar);
   }
 
   update(_deltaTime: number): void {
+    this.tweens.tick(_deltaTime);
+
     if (this.isRollingDice) {
       this.rollAnimationFrame += 1;
       if (this.rollAnimationFrame >= this.rollAnimationDuration) {
@@ -565,6 +588,7 @@ export class BackgammonRenderer implements GameRenderer {
 
   destroy(): void {
     this.unsubscribeFromRoomEvents();
+    this.tweens.cancelAll();
     this.room = null;
     this.requestLeave = null;
     this.players.clear();
@@ -576,6 +600,7 @@ export class BackgammonRenderer implements GameRenderer {
     this.sidebar?.destroy();
     this.sidebar = null;
     this.clearPieces();
+    this.animLayer.removeChildren();
     this.pointGraphics.length = 0;
     this.container.destroy({ children: true });
   }
@@ -1106,6 +1131,121 @@ export class BackgammonRenderer implements GameRenderer {
     for (const child of this.piecesLayer.removeChildren()) {
       child.destroy();
     }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Piece movement animation
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  private snapshotBoardState(): void {
+    this.prevPoints = [...this.points];
+    this.prevBlackBar = this.blackBar;
+    this.prevRedBar = this.redBar;
+  }
+
+  /**
+   * Detect which point lost a piece and which gained one, then animate
+   * a temporary disc from the source to the destination.
+   */
+  private animatePieceMovement(
+    oldPoints: number[],
+    oldBlackBar: number,
+    oldRedBar: number,
+  ): void {
+    const discRadius = Math.max(10, this.pointWidth * 0.38);
+    const outlineWidth = Math.max(1, this.pointWidth * 0.05);
+    const edgePadding = Math.max(8, this.pointWidth * 0.14);
+
+    // Determine which color moved: compare bar and point changes
+    let movedColor: BackgammonColor | null = null;
+    let fromPos: { x: number; y: number } | null = null;
+    let toPos: { x: number; y: number } | null = null;
+
+    // Check for bar entry (piece leaving bar)
+    const barCenterX = this.playX + (POINTS_PER_QUADRANT * this.pointWidth) + (this.barWidth / 2);
+    const blackBarHalfHeight = (this.playHeight - this.centerGap) / 2;
+
+    if (this.blackBar < oldBlackBar) {
+      movedColor = BLACK;
+      const barY = this.isFlipped
+        ? this.playY + this.playHeight - this.centerGap / 2 - blackBarHalfHeight / 2
+        : this.playY + this.centerGap / 2 + blackBarHalfHeight / 2;
+      fromPos = { x: barCenterX, y: barY };
+    } else if (this.redBar < oldRedBar) {
+      movedColor = RED;
+      const barY = this.isFlipped
+        ? this.playY + this.centerGap / 2 + blackBarHalfHeight / 2
+        : this.playY + this.playHeight - this.centerGap / 2 - blackBarHalfHeight / 2;
+      fromPos = { x: barCenterX, y: barY };
+    }
+
+    // Find source and destination points from board diffs
+    for (let i = 0; i < BOARD_POINT_COUNT; i += 1) {
+      const diff = this.points[i] - oldPoints[i];
+      if (diff === 0) continue;
+
+      const geometry = this.getPointGeometry(i);
+      const centerX = geometry.x + (geometry.width / 2);
+      const isTopRow = geometry.isTopRow;
+      const originY = isTopRow
+        ? this.playY + discRadius + edgePadding
+        : this.playY + this.playHeight - discRadius - edgePadding;
+
+      if (diff > 0 && movedColor === null) {
+        // Gained positive pieces → BLACK moved here
+        movedColor = BLACK;
+      } else if (diff < 0 && movedColor === null) {
+        // Gained negative pieces → RED moved here (or BLACK left)
+        movedColor = RED;
+      }
+
+      // Source: point lost a piece of the moving color
+      if (fromPos === null) {
+        if ((movedColor === BLACK && diff < 0) || (movedColor === RED && diff > 0)) {
+          const stackCount = Math.abs(oldPoints[i]);
+          const stackSpacing = discRadius * 0.56;
+          const direction = isTopRow ? 1 : -1;
+          const topPieceIndex = Math.min(stackCount, MAX_VISIBLE_STACK) - 1;
+          fromPos = { x: centerX, y: originY + stackSpacing * topPieceIndex * direction };
+        }
+      }
+
+      // Destination: point gained a piece of the moving color
+      if ((movedColor === BLACK && diff > 0) || (movedColor === RED && diff < 0)) {
+        const stackCount = Math.abs(this.points[i]);
+        const stackSpacing = discRadius * 0.56;
+        const direction = isTopRow ? 1 : -1;
+        const topPieceIndex = Math.min(stackCount, MAX_VISIBLE_STACK) - 1;
+        toPos = { x: centerX, y: originY + stackSpacing * topPieceIndex * direction };
+      }
+    }
+
+    if (!fromPos || !toPos || !movedColor) return;
+
+    // Create a temporary disc for the animation
+    const animPiece = new Graphics();
+    animPiece.eventMode = "none";
+
+    const bodyGradient = createPieceBodyGradient(this.getPieceVariant(movedColor));
+    const highlightGradient = createPieceHighlightGradient();
+    animPiece.circle(0, 0, discRadius)
+      .fill(bodyGradient)
+      .stroke({ color: this.getPieceBorderColor(movedColor), width: outlineWidth, alpha: 0.95 });
+    animPiece.circle(0, 0, discRadius * 0.92)
+      .fill(highlightGradient);
+
+    this.animLayer.addChild(animPiece);
+
+    this.tweens.animate(animPiece, {
+      fromX: fromPos.x,
+      fromY: fromPos.y,
+      toX: toPos.x,
+      toY: toPos.y,
+      duration: PIECE_ANIM_DURATION_MS,
+      onComplete: () => {
+        animPiece.destroy();
+      },
+    });
   }
 
   private handlePointClick(index: number): void {

--- a/client/src/renderers/BackgammonRenderer.ts
+++ b/client/src/renderers/BackgammonRenderer.ts
@@ -1191,12 +1191,17 @@ export class BackgammonRenderer implements GameRenderer {
         ? this.playY + discRadius + edgePadding
         : this.playY + this.playHeight - discRadius - edgePadding;
 
-      if (diff > 0 && movedColor === null) {
-        // Gained positive pieces → BLACK moved here
-        movedColor = BLACK;
-      } else if (diff < 0 && movedColor === null) {
-        // Gained negative pieces → RED moved here (or BLACK left)
-        movedColor = RED;
+      // Determine color from point value signs, not diff direction
+      if (movedColor === null) {
+        if (oldPoints[i] > 0 && diff < 0) {
+          movedColor = BLACK;
+        } else if (oldPoints[i] < 0 && diff > 0) {
+          movedColor = RED;
+        } else if (this.points[i] > 0 && diff > 0) {
+          movedColor = BLACK;
+        } else if (this.points[i] < 0 && diff < 0) {
+          movedColor = RED;
+        }
       }
 
       // Source: point lost a piece of the moving color

--- a/client/src/renderers/CheckersRenderer.ts
+++ b/client/src/renderers/CheckersRenderer.ts
@@ -723,37 +723,37 @@ export class CheckersRenderer implements GameRenderer {
    * then animate a temporary piece from the source to the destination.
    */
   private animatePieceMovement(oldBoard: number[]): void {
-    // Find source (had a piece, now empty) and destination (was empty, now has a piece)
+    // Find destination: was empty, now has a piece
     let fromIndex = -1;
     let toIndex = -1;
     let movedPiece = EMPTY;
 
     for (let i = 0; i < BOARD_CELL_COUNT; i += 1) {
-      const prev = oldBoard[i];
-      const curr = this.board[i];
-      if (prev !== EMPTY && curr === EMPTY && fromIndex === -1) {
-        fromIndex = i;
-      }
-      if (prev === EMPTY && curr !== EMPTY && toIndex === -1) {
+      if (oldBoard[i] === EMPTY && this.board[i] !== EMPTY) {
         toIndex = i;
-        movedPiece = curr;
+        movedPiece = this.board[i];
+        break;
       }
     }
 
-    // Also handle promotion: piece type changed but same color
-    if (toIndex === -1) {
-      for (let i = 0; i < BOARD_CELL_COUNT; i += 1) {
-        const prev = oldBoard[i];
-        const curr = this.board[i];
-        if (prev === EMPTY && curr !== EMPTY) {
-          toIndex = i;
-          movedPiece = curr;
+    if (toIndex < 0 || movedPiece === EMPTY) return;
+
+    // Determine the color of the moved piece
+    const movedIsBlack = movedPiece === BLACK || movedPiece === BLACK_KING;
+
+    // Find source: square where a piece of the SAME color left (now empty).
+    // Ignore captured opponent squares which also become empty.
+    for (let i = 0; i < BOARD_CELL_COUNT; i += 1) {
+      if (this.board[i] === EMPTY && oldBoard[i] !== EMPTY) {
+        const prevIsBlack = oldBoard[i] === BLACK || oldBoard[i] === BLACK_KING;
+        if (movedIsBlack === prevIsBlack) {
+          fromIndex = i;
           break;
         }
       }
     }
 
-    if (fromIndex < 0 || toIndex < 0 || movedPiece === EMPTY) return;
+    if (fromIndex < 0) return;
 
     const from = this.getSquareCenter(fromIndex);
     const to = this.getSquareCenter(toIndex);

--- a/client/src/renderers/CheckersRenderer.ts
+++ b/client/src/renderers/CheckersRenderer.ts
@@ -18,6 +18,7 @@ import {
 } from "../games/checkers/checkersClientLogic";
 import { GameSidebar, escapeHtml, getTurnClockMarkup, getChessClockMarkup } from "../ui/GameSidebar";
 import { DragHelper } from "./DragHelper";
+import { TweenManager } from "./TweenManager";
 import {
   ACCENT_BLUE,
   AMBER_500,
@@ -92,6 +93,7 @@ const MAX_SIDEBAR_HISTORY_ITEMS = 8;
 const COORD_LABEL_COLOR = 0xa8a29e;
 const COLUMN_LETTERS = ["A", "B", "C", "D", "E", "F", "G", "H"];
 const ROW_NUMBERS = ["8", "7", "6", "5", "4", "3", "2", "1"];
+const PIECE_ANIM_DURATION_MS = 250;
 
 function toCssHexColor(color: number): string {
   return `#${color.toString(16).padStart(6, "0")}`;
@@ -205,6 +207,11 @@ export class CheckersRenderer implements GameRenderer {
   private boardOffsetY = TOP_HUD_SPACE
     + ((DEFAULT_HEIGHT - TOP_HUD_SPACE - BOTTOM_HUD_SPACE - this.boardSize) / 2);
 
+  // Piece movement animation
+  private readonly animLayer = new Container();
+  private readonly tweens = new TweenManager();
+  private prevBoard: number[] = Array.from({ length: BOARD_CELL_COUNT }, () => EMPTY);
+
   constructor() {
     this.container.eventMode = "static";
     this.piecesLayer.eventMode = "none";
@@ -271,6 +278,7 @@ export class CheckersRenderer implements GameRenderer {
       this.coordLabelsContainer,
       this.boardLayer,
       this.piecesLayer,
+      this.animLayer,
       this.dragLayer,
       this.capturedPiecesGraphics,
       this.blackCountText,
@@ -298,6 +306,7 @@ export class CheckersRenderer implements GameRenderer {
     this.moveHistory = [];
     this.turnClockSeconds = null;
     this.showTurnClock = false;
+    this.tweens.cancelAll();
     this.sidebar?.destroy();
     this.sidebar = new GameSidebar();
     this.sidebar.addPanel("game-info", "Game Info");
@@ -307,6 +316,7 @@ export class CheckersRenderer implements GameRenderer {
     this.sidebar.show();
     this.subscribeToRoomEvents();
     this.applyState(state);
+    this.prevBoard = [...this.board];
     this.layout();
     this.redrawBoard();
     this.redrawPieces();
@@ -317,7 +327,12 @@ export class CheckersRenderer implements GameRenderer {
 
   onStateChange(state: unknown): void {
     this.movePending = false;
+
+    // Snapshot previous board for animation detection
+    const oldBoard = this.prevBoard;
+
     this.applyState(state);
+    this.prevBoard = [...this.board];
     this.syncSelectionWithState();
 
     // Only cancel a drag if the source piece is no longer valid (e.g. turn changed,
@@ -334,9 +349,13 @@ export class CheckersRenderer implements GameRenderer {
     this.updateHud();
     this.updateGameOverOverlay();
     this.updateSidebar();
+
+    this.animatePieceMovement(oldBoard);
   }
 
-  update(_deltaTime: number): void {}
+  update(deltaTime: number): void {
+    this.tweens.tick(deltaTime);
+  }
 
   resize(width: number, height: number): void {
     this.width = width;
@@ -370,6 +389,7 @@ export class CheckersRenderer implements GameRenderer {
 
   destroy(): void {
     this.unsubscribeFromRoomEvents();
+    this.tweens.cancelAll();
     this.dragHelper?.destroy();
     this.dragHelper = null;
     this.dragSourceIndex = null;
@@ -384,6 +404,7 @@ export class CheckersRenderer implements GameRenderer {
     this.sidebar?.destroy();
     this.sidebar = null;
     this.clearPieces();
+    this.animLayer.removeChildren();
     this.capturedPiecesGraphics.clear();
     this.squareGraphics.length = 0;
     this.container.destroy({ children: true });
@@ -680,6 +701,99 @@ export class CheckersRenderer implements GameRenderer {
     for (const child of this.piecesLayer.removeChildren()) {
       child.destroy();
     }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Piece movement animation
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** Convert a board index to pixel center coordinates for animation. */
+  private getSquareCenter(boardIndex: number): { x: number; y: number } {
+    const displayIndex = this.toDisplayIndex(boardIndex);
+    const row = Math.floor(displayIndex / BOARD_DIMENSION);
+    const column = displayIndex % BOARD_DIMENSION;
+    return {
+      x: this.boardOffsetX + (column * this.squareSize) + (this.squareSize / 2),
+      y: this.boardOffsetY + (row * this.squareSize) + (this.squareSize / 2),
+    };
+  }
+
+  /**
+   * Detect which piece moved by comparing the previous board to the current one,
+   * then animate a temporary piece from the source to the destination.
+   */
+  private animatePieceMovement(oldBoard: number[]): void {
+    // Find source (had a piece, now empty) and destination (was empty, now has a piece)
+    let fromIndex = -1;
+    let toIndex = -1;
+    let movedPiece = EMPTY;
+
+    for (let i = 0; i < BOARD_CELL_COUNT; i += 1) {
+      const prev = oldBoard[i];
+      const curr = this.board[i];
+      if (prev !== EMPTY && curr === EMPTY && fromIndex === -1) {
+        fromIndex = i;
+      }
+      if (prev === EMPTY && curr !== EMPTY && toIndex === -1) {
+        toIndex = i;
+        movedPiece = curr;
+      }
+    }
+
+    // Also handle promotion: piece type changed but same color
+    if (toIndex === -1) {
+      for (let i = 0; i < BOARD_CELL_COUNT; i += 1) {
+        const prev = oldBoard[i];
+        const curr = this.board[i];
+        if (prev === EMPTY && curr !== EMPTY) {
+          toIndex = i;
+          movedPiece = curr;
+          break;
+        }
+      }
+    }
+
+    if (fromIndex < 0 || toIndex < 0 || movedPiece === EMPTY) return;
+
+    const from = this.getSquareCenter(fromIndex);
+    const to = this.getSquareCenter(toIndex);
+
+    const pieceRadius = this.squareSize * 0.32;
+    const outlineWidth = Math.max(1, this.squareSize * 0.04);
+    const isBlackPiece = movedPiece === BLACK || movedPiece === BLACK_KING;
+    const pieceGradient = isBlackPiece ? createPieceBodyGradient("black") : createPieceBodyGradient("red");
+    const pieceBorder = isBlackPiece ? PIECE_BLACK_BORDER : PIECE_RED_BORDER;
+    const highlightGradient = createPieceHighlightGradient();
+
+    const animPiece = new Graphics();
+    animPiece.eventMode = "none";
+
+    animPiece.circle(0, 0, pieceRadius)
+      .fill(pieceGradient)
+      .stroke({ color: pieceBorder, width: outlineWidth });
+    animPiece.circle(-pieceRadius * 0.15, -pieceRadius * 0.2, pieceRadius * 0.38)
+      .fill(highlightGradient);
+
+    if (movedPiece === BLACK_KING || movedPiece === RED_KING) {
+      animPiece.circle(0, 0, pieceRadius * 0.58).stroke({
+        color: KING_MARKER_COLOR,
+        alpha: KING_CROWN_RING_ALPHA,
+        width: Math.max(3, this.squareSize * 0.05),
+      });
+    }
+
+    this.animLayer.addChild(animPiece);
+
+    this.tweens.animate(animPiece, {
+      fromX: from.x,
+      fromY: from.y,
+      toX: to.x,
+      toY: to.y,
+      duration: PIECE_ANIM_DURATION_MS,
+      onComplete: () => {
+        animPiece.destroy();
+      },
+    });
   }
 
   private handleSquareHover(displayIndex: number | null): void {

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -863,11 +863,9 @@ export class DominosRenderer implements GameRenderer {
    * temporary clone in the animation layer that tweens into place.
    */
   private animateTilePlacement(tile: BoardTileSnapshot): void {
-    // Determine the board position of the new tile
-    const tileIndex = this.boardTiles.indexOf(tile);
-    if (tileIndex < 0) return;
-
-    const boardChild = this.boardLayer.children[tileIndex];
+    const boardChild = this.boardLayer.children.find(
+      (c) => c.label === `board-tile-${tile.id}`,
+    );
     if (!boardChild) return;
 
     const toX = boardChild.position.x;
@@ -993,6 +991,7 @@ export class DominosRenderer implements GameRenderer {
       const w = BOARD_TILE_W * scale;
       const h = BOARD_TILE_H * scale;
       this.drawBoardTile(g, bt, x, y, w, h, "horizontal", scale);
+      g.label = `board-tile-${bt.id}`;
       g.eventMode = "none";
       this.boardLayer.addChild(g);
     }
@@ -1060,6 +1059,7 @@ export class DominosRenderer implements GameRenderer {
     const sY = spinnerCY - (spinnerH * scale) / 2;
     const spinnerG = new Graphics();
     this.drawBoardTile(spinnerG, spinner, sX, sY, spinnerW * scale, spinnerH * scale, "vertical", scale);
+    spinnerG.label = `board-tile-${spinner.id}`;
     spinnerG.eventMode = "none";
     this.boardLayer.addChild(spinnerG);
 
@@ -1073,6 +1073,7 @@ export class DominosRenderer implements GameRenderer {
       const tY = spinnerCY - th / 2;
       const g = new Graphics();
       this.drawBoardTile(g, bt, cursorX, tY, tw, th, bt.isDouble ? "vertical" : "horizontal", scale);
+      g.label = `board-tile-${bt.id}`;
       g.eventMode = "none";
       this.boardLayer.addChild(g);
       cursorX -= BOARD_TILE_GAP * scale;
@@ -1088,6 +1089,7 @@ export class DominosRenderer implements GameRenderer {
       const tY = spinnerCY - th / 2;
       const g = new Graphics();
       this.drawBoardTile(g, bt, cursorX, tY, tw, th, bt.isDouble ? "vertical" : "horizontal", scale);
+      g.label = `board-tile-${bt.id}`;
       g.eventMode = "none";
       this.boardLayer.addChild(g);
       cursorX += tw + BOARD_TILE_GAP * scale;
@@ -1104,6 +1106,7 @@ export class DominosRenderer implements GameRenderer {
       const tX = spinnerCX - tw / 2;
       const g = new Graphics();
       this.drawBoardTile(g, bt, tX, cursorY, tw, th, bt.isDouble ? "horizontal" : "vertical", scale);
+      g.label = `board-tile-${bt.id}`;
       g.eventMode = "none";
       this.boardLayer.addChild(g);
       cursorY -= BOARD_TILE_GAP * scale;
@@ -1119,6 +1122,7 @@ export class DominosRenderer implements GameRenderer {
       const tX = spinnerCX - tw / 2;
       const g = new Graphics();
       this.drawBoardTile(g, bt, tX, cursorY, tw, th, bt.isDouble ? "horizontal" : "vertical", scale);
+      g.label = `board-tile-${bt.id}`;
       g.eventMode = "none";
       this.boardLayer.addChild(g);
       cursorY += th + BOARD_TILE_GAP * scale;

--- a/client/src/renderers/DominosRenderer.ts
+++ b/client/src/renderers/DominosRenderer.ts
@@ -7,6 +7,7 @@ import type {
 import { Container, Graphics, Text } from "pixi.js";
 import { GameSidebar, escapeHtml, getTurnClockMarkup } from "../ui/GameSidebar";
 import { DragHelper } from "./DragHelper";
+import { TweenManager } from "./TweenManager";
 import {
   ACCENT_BLUE,
   AMBER_500,
@@ -91,6 +92,8 @@ const OVERLAY_BACKDROP_COLOR = BG_PRIMARY;
 const OVERLAY_BACKDROP_ALPHA = 0.66;
 
 const GAME_ENDED_MESSAGE = "game-end";
+
+const TILE_ANIM_DURATION_MS = 250;
 
 // ── Pip layout positions (normalised to 0..1 inside a half-tile) ────────────
 // Standard domino pip patterns for 0-6
@@ -259,6 +262,11 @@ export class DominosRenderer implements GameRenderer {
   private prevArmsCDLocked = true;
   private spinnerUnlockFlashTimer = 0;
 
+  // Tile placement animation
+  private readonly animLayer = new Container();
+  private readonly tweens = new TweenManager();
+  private prevBoardTileIds = new Set<number>();
+
   constructor() {
     this.container.eventMode = "static";
     this.overlayLayer.eventMode = "none";
@@ -291,6 +299,7 @@ export class DominosRenderer implements GameRenderer {
     this.container.addChild(
       this.boardBackground,
       this.boardLayer,
+      this.animLayer,
       this.spinnerIndicatorLayer,
       this.ghostLayer,
       this.endMarkerA,
@@ -327,6 +336,7 @@ export class DominosRenderer implements GameRenderer {
     this.dragTileId = null;
     this.turnClockSeconds = null;
     this.showTurnClock = false;
+    this.tweens.cancelAll();
 
     this.sidebar?.destroy();
     this.sidebar = new GameSidebar();
@@ -338,6 +348,7 @@ export class DominosRenderer implements GameRenderer {
 
     this.subscribeToRoomEvents();
     this.applyState(state);
+    this.prevBoardTileIds = new Set(this.boardTiles.map((t) => t.id));
     this.layout();
     this.redrawAll();
   }
@@ -348,7 +359,14 @@ export class DominosRenderer implements GameRenderer {
     // Detect C/D arm unlock transition (locked → active)
     const wasCDLocked = this.openEndC < 0 && this.openEndD < 0;
 
+    // Snapshot board tile IDs before state update for animation detection
+    const prevIds = this.prevBoardTileIds;
+
     this.applyState(state);
+
+    // Update prev-board snapshot for next state change
+    const currentIds = new Set(this.boardTiles.map((t) => t.id));
+    this.prevBoardTileIds = currentIds;
 
     const isCDActive = this.openEndC >= 0 || this.openEndD >= 0;
     if (wasCDLocked && isCDActive && this.spinnerTileId !== -1) {
@@ -368,9 +386,19 @@ export class DominosRenderer implements GameRenderer {
     }
 
     this.redrawAll();
+
+    // Animate newly placed tile from hand area to board position
+    if (prevIds.size > 0) {
+      const newTile = this.boardTiles.find((t) => !prevIds.has(t.id));
+      if (newTile) {
+        this.animateTilePlacement(newTile);
+      }
+    }
   }
 
   update(deltaTime: number): void {
+    this.tweens.tick(deltaTime);
+
     if (this.spinnerUnlockFlashTimer > 0) {
       this.spinnerUnlockFlashTimer -= deltaTime;
       if (this.spinnerUnlockFlashTimer <= 0) {
@@ -408,6 +436,7 @@ export class DominosRenderer implements GameRenderer {
 
   destroy(): void {
     this.unsubscribeFromRoomEvents();
+    this.tweens.cancelAll();
     this.dragHelper?.destroy();
     this.dragHelper = null;
     this.dragTileId = null;
@@ -424,6 +453,7 @@ export class DominosRenderer implements GameRenderer {
     this.sidebar?.destroy();
     this.sidebar = null;
     this.boardLayer.removeChildren();
+    this.animLayer.removeChildren();
     this.spinnerIndicatorLayer.removeChildren();
     this.ghostLayer.removeChildren();
     this.handLayer.removeChildren();
@@ -821,6 +851,71 @@ export class DominosRenderer implements GameRenderer {
     this.redrawEndMarkers();
     this.updateOverlay();
     this.updateSidebar();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tile placement animation
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Animate a newly placed tile sliding from the hand area to its board position.
+   * Finds the tile's Graphics child inside boardLayer by index and creates a
+   * temporary clone in the animation layer that tweens into place.
+   */
+  private animateTilePlacement(tile: BoardTileSnapshot): void {
+    // Determine the board position of the new tile
+    const tileIndex = this.boardTiles.indexOf(tile);
+    if (tileIndex < 0) return;
+
+    const boardChild = this.boardLayer.children[tileIndex];
+    if (!boardChild) return;
+
+    const toX = boardChild.position.x;
+    const toY = boardChild.position.y;
+
+    // Origin: center-bottom of screen (hand area)
+    const fromX = this.width / 2;
+    const fromY = this.height - HAND_AREA_HEIGHT / 2;
+
+    // Create a temporary Graphics clone for the animation
+    const animTile = new Graphics();
+    animTile.eventMode = "none";
+
+    const scale = this.boardScale;
+    if (this.layoutMode === "linear") {
+      const w = BOARD_TILE_W * scale;
+      const h = BOARD_TILE_H * scale;
+      this.drawBoardTile(animTile, tile, 0, 0, w, h, "horizontal", scale);
+    } else {
+      const isSpinner = tile.arm === "spinner";
+      const isVerticalArm = tile.arm === "c" || tile.arm === "d";
+      if (isSpinner) {
+        const w = BOARD_TILE_H * scale;
+        const h = BOARD_TILE_W * scale;
+        this.drawBoardTile(animTile, tile, 0, 0, w, h, "vertical", scale);
+      } else if (isVerticalArm) {
+        const w = (tile.isDouble ? BOARD_TILE_W : BOARD_TILE_H) * scale;
+        const h = (tile.isDouble ? BOARD_TILE_H : BOARD_TILE_W) * scale;
+        this.drawBoardTile(animTile, tile, 0, 0, w, h, tile.isDouble ? "horizontal" : "vertical", scale);
+      } else {
+        const w = (tile.isDouble ? BOARD_TILE_H : BOARD_TILE_W) * scale;
+        const h = (tile.isDouble ? BOARD_TILE_W : BOARD_TILE_H) * scale;
+        this.drawBoardTile(animTile, tile, 0, 0, w, h, tile.isDouble ? "vertical" : "horizontal", scale);
+      }
+    }
+
+    this.animLayer.addChild(animTile);
+
+    this.tweens.animate(animTile, {
+      fromX,
+      fromY,
+      toX,
+      toY,
+      duration: TILE_ANIM_DURATION_MS,
+      onComplete: () => {
+        animTile.destroy();
+      },
+    });
   }
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/client/src/renderers/TweenManager.test.ts
+++ b/client/src/renderers/TweenManager.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import { TweenManager } from "./TweenManager";
+
+function makeTarget(x = 0, y = 0) {
+  return {
+    position: { x, y, set(nx: number, ny: number) { this.x = nx; this.y = ny; } },
+    alpha: 1,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("TweenManager", () => {
+  it("moves target from A to B over duration", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 100, toY: 200, duration: 100 });
+    expect(tm.activeCount).toBe(1);
+
+    // Half-way (ease-out cubic at 0.5 ≈ 0.875)
+    tm.tick(50);
+    expect(target.position.x).toBeGreaterThan(50);
+    expect(target.position.y).toBeGreaterThan(100);
+
+    // Complete
+    tm.tick(50);
+    expect(target.position.x).toBe(100);
+    expect(target.position.y).toBe(200);
+    expect(tm.activeCount).toBe(0);
+  });
+
+  it("calls onComplete when animation finishes", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+    const onComplete = vi.fn();
+
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 10, toY: 10, duration: 50, onComplete });
+    tm.tick(50);
+
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("cancels previous tween when re-animating same target", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 100, toY: 100, duration: 200 });
+    tm.animate(target, { fromX: 50, fromY: 50, toX: 200, toY: 200, duration: 100 });
+
+    expect(tm.activeCount).toBe(1);
+    expect(target.position.x).toBe(50);
+  });
+
+  it("cancelAll clears every tween", () => {
+    const tm = new TweenManager();
+    const t1 = makeTarget();
+    const t2 = makeTarget();
+
+    tm.animate(t1, { fromX: 0, fromY: 0, toX: 100, toY: 100, duration: 100 });
+    tm.animate(t2, { fromX: 0, fromY: 0, toX: 100, toY: 100, duration: 100 });
+    expect(tm.activeCount).toBe(2);
+
+    tm.cancelAll();
+    expect(tm.activeCount).toBe(0);
+  });
+
+  it("animates alpha when specified", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 0, toY: 0, fromAlpha: 0, toAlpha: 1, duration: 100 });
+    expect(target.alpha).toBe(0);
+
+    tm.tick(100);
+    expect(target.alpha).toBe(1);
+  });
+
+  it("tick returns false when no tweens are active", () => {
+    const tm = new TweenManager();
+    expect(tm.tick(16)).toBe(false);
+  });
+
+  it("tick returns true when tweens are running", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 10, toY: 10, duration: 100 });
+
+    expect(tm.tick(16)).toBe(true);
+  });
+
+  it("handles overshoot (deltaMs exceeds duration)", () => {
+    const tm = new TweenManager();
+    const target = makeTarget();
+
+    tm.animate(target, { fromX: 0, fromY: 0, toX: 100, toY: 200, duration: 50 });
+    tm.tick(200);
+
+    expect(target.position.x).toBe(100);
+    expect(target.position.y).toBe(200);
+    expect(tm.activeCount).toBe(0);
+  });
+});

--- a/client/src/renderers/TweenManager.ts
+++ b/client/src/renderers/TweenManager.ts
@@ -1,0 +1,126 @@
+import type { Container } from "pixi.js";
+
+/** Ease-out cubic: fast start, smooth deceleration */
+function easeOutCubic(t: number): number {
+  return 1 - (1 - t) ** 3;
+}
+
+type TweenTarget = Container;
+
+type ActiveTween = {
+  target: TweenTarget;
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+  fromAlpha: number;
+  toAlpha: number;
+  elapsed: number;
+  duration: number;
+  onComplete?: () => void;
+};
+
+const DEFAULT_DURATION_MS = 250;
+
+/**
+ * Lightweight, interruptible tween manager for PixiJS DisplayObjects.
+ * Driven by the renderer's existing `update(deltaTime)` loop — no extra
+ * ticker subscriptions required.
+ *
+ * Usage:
+ *   tweens.animate(sprite, { fromX, fromY, toX, toY, duration });
+ *   // in update():
+ *   tweens.tick(deltaTime);
+ */
+export class TweenManager {
+  private readonly tweens: ActiveTween[] = [];
+
+  /** Number of active animations (useful for tests / debug) */
+  get activeCount(): number {
+    return this.tweens.length;
+  }
+
+  /**
+   * Animate a DisplayObject from one position to another.
+   * If the target already has an active tween, the old one is cancelled.
+   */
+  animate(
+    target: TweenTarget,
+    options: {
+      fromX: number;
+      fromY: number;
+      toX: number;
+      toY: number;
+      fromAlpha?: number;
+      toAlpha?: number;
+      duration?: number;
+      onComplete?: () => void;
+    },
+  ): void {
+    this.cancel(target);
+
+    const tween: ActiveTween = {
+      target,
+      fromX: options.fromX,
+      fromY: options.fromY,
+      toX: options.toX,
+      toY: options.toY,
+      fromAlpha: options.fromAlpha ?? 1,
+      toAlpha: options.toAlpha ?? 1,
+      elapsed: 0,
+      duration: options.duration ?? DEFAULT_DURATION_MS,
+      onComplete: options.onComplete,
+    };
+
+    target.position.set(tween.fromX, tween.fromY);
+    target.alpha = tween.fromAlpha;
+    this.tweens.push(tween);
+  }
+
+  /** Cancel any running tween on the given target. */
+  cancel(target: TweenTarget): void {
+    for (let i = this.tweens.length - 1; i >= 0; i -= 1) {
+      if (this.tweens[i].target === target) {
+        this.tweens.splice(i, 1);
+      }
+    }
+  }
+
+  /** Cancel all active tweens. */
+  cancelAll(): void {
+    this.tweens.length = 0;
+  }
+
+  /**
+   * Advance all tweens by `deltaMs` milliseconds.
+   * Call this from the renderer's `update(deltaTime)` method.
+   * Returns true if any tween was active (caller may want to skip redraws).
+   */
+  tick(deltaMs: number): boolean {
+    if (this.tweens.length === 0) {
+      return false;
+    }
+
+    for (let i = this.tweens.length - 1; i >= 0; i -= 1) {
+      const tw = this.tweens[i];
+      tw.elapsed += deltaMs;
+      const progress = Math.min(tw.elapsed / tw.duration, 1);
+      const eased = easeOutCubic(progress);
+
+      tw.target.position.set(
+        tw.fromX + (tw.toX - tw.fromX) * eased,
+        tw.fromY + (tw.toY - tw.fromY) * eased,
+      );
+      tw.target.alpha = tw.fromAlpha + (tw.toAlpha - tw.fromAlpha) * eased;
+
+      if (progress >= 1) {
+        tw.target.position.set(tw.toX, tw.toY);
+        tw.target.alpha = tw.toAlpha;
+        tw.onComplete?.();
+        this.tweens.splice(i, 1);
+      }
+    }
+
+    return true;
+  }
+}

--- a/client/src/renderers/TweenManager.ts
+++ b/client/src/renderers/TweenManager.ts
@@ -86,8 +86,11 @@ export class TweenManager {
     }
   }
 
-  /** Cancel all active tweens. */
+  /** Cancel all active tweens, firing onComplete so animated objects are cleaned up. */
   cancelAll(): void {
+    for (const tw of this.tweens) {
+      tw.onComplete?.();
+    }
     this.tweens.length = 0;
   }
 
@@ -104,7 +107,7 @@ export class TweenManager {
     for (let i = this.tweens.length - 1; i >= 0; i -= 1) {
       const tw = this.tweens[i];
       tw.elapsed += deltaMs;
-      const progress = Math.min(tw.elapsed / tw.duration, 1);
+      const progress = tw.duration <= 0 ? 1 : Math.min(tw.elapsed / tw.duration, 1);
       const eased = easeOutCubic(progress);
 
       tw.target.position.set(


### PR DESCRIPTION
## Summary

Adds snappy, interruptible placement animations to all three games so pieces animate into position instead of instantly appearing. Especially helpful for CPU opponent moves which were previously instant and hard to follow.

### What changed

- **New: `TweenManager`** — Lightweight ticker-based tween utility (~120 lines) with ease-out cubic easing, cancellation, and alpha support. Fully tested (8 unit tests).
- **DominosRenderer** — Newly placed tiles animate from the hand area to their board position.
- **BackgammonRenderer** — Pieces animate between points (including bar → board re-entry).
- **CheckersRenderer** — Pieces slide from source square to destination square.

### Design

- 250ms duration with ease-out cubic for natural deceleration
- Driven by the existing `update(deltaTime)` loop — no new ticker subscriptions
- Each renderer snapshots previous state before `applyState()`, detects what moved, then spawns a temporary `Graphics` in an `animLayer` that tweens into place
- Animations are interruptible: cancelled on `init()`, `destroy()`, and when a new animation supersedes an old one
- DragHelper interactions are preserved (drags are never cancelled by animations)

### Validation

- `npm run build` ✅
- `npm run lint` ✅
- `npm run test` ✅ (811 passed, 12 todo)

Refs #177