### PR TITLE
feat: support multiple CPU players in multi-player games

### DIFF
--- a/client/src/renderers/CheckersRenderer.ts
+++ b/client/src/renderers/CheckersRenderer.ts
@@ -2,6 +2,7 @@ import type { Room } from "@colyseus/sdk";
 import {
   BLACK,
   BLACK_KING,
+  CPU_SESSION_ID_PREFIX,
   EMPTY,
   RED,
   RED_KING,
@@ -1144,7 +1145,7 @@ export class CheckersRenderer implements GameRenderer {
     return Array.from(this.players.entries()).some(([sessionId, player]) => (
       !player.isSpectator
       && sessionId !== localSessionId
-      && sessionId !== "cpu-opponent"
+      && !sessionId.startsWith(CPU_SESSION_ID_PREFIX)
       && player.controllerSessionId === localSessionId
     ));
   }

--- a/client/src/ui/SetupScreen.ts
+++ b/client/src/ui/SetupScreen.ts
@@ -1127,13 +1127,11 @@ export class SetupScreen {
     // Always show empty slots so the host can add CPU players
     const maxPlayers = this.gameInfo?.maxPlayers ?? 0;
     const emptySlots = Math.max(0, maxPlayers - this.players.length);
-    const hasCpu = this.players.some((p) => p.isCPU);
 
     if (
       emptySlots > 0 &&
       this.isHost &&
-      this.supportsCpuOpponent() &&
-      !hasCpu
+      this.supportsCpuOpponent()
     ) {
       // First empty slot becomes an "Add CPU" button
       const cpuSlot = el("div", "setup-add-cpu-slot");
@@ -1198,6 +1196,7 @@ export class SetupScreen {
     if (player.isCPU) {
       nameRow.append(el("span", "setup-player-chip", "CPU"));
       if (this.isHost) {
+        const cpuUserId = player.userId;
         const removeBtn = el("button", "setup-remove-cpu-btn") as HTMLButtonElement;
         removeBtn.type = "button";
         removeBtn.title = "Remove CPU player";
@@ -1206,7 +1205,7 @@ export class SetupScreen {
           removeBtn.disabled = true;
         } else {
           removeBtn.textContent = "✕";
-          removeBtn.addEventListener("click", () => this.requestRemoveCpu());
+          removeBtn.addEventListener("click", () => this.requestRemoveCpu(cpuUserId));
         }
         nameRow.append(removeBtn);
       }
@@ -1370,13 +1369,13 @@ export class SetupScreen {
     }
   }
 
-  private requestRemoveCpu(): void {
+  private requestRemoveCpu(cpuSessionId: string): void {
     if (!this.room || !this.gameId || this.cpuRemovePending) {
       return;
     }
 
     this.cpuRemovePending = true;
-    this.room.send(REMOVE_CPU_PLAYER, { gameId: this.gameId });
+    this.room.send(REMOVE_CPU_PLAYER, { gameId: this.gameId, cpuSessionId });
     this.renderPlayerList();
 
     this.cpuRemoveTimeoutId = window.setTimeout(() => {
@@ -1415,9 +1414,8 @@ export class SetupScreen {
   }
 
   private updateInviteVisibility(): void {
-    const hasCpu = this.players.some((p) => p.isCPU);
     const isFull = this.gameInfo != null && this.players.length >= this.gameInfo.maxPlayers;
-    this.inviteSection.style.display = this.mode === "waiting" && !hasCpu && !isFull ? "" : "none";
+    this.inviteSection.style.display = this.mode === "waiting" && !isFull ? "" : "none";
   }
 
   private async copyJoinLink(): Promise<void> {

--- a/client/src/ui/WaitingRoom.ts
+++ b/client/src/ui/WaitingRoom.ts
@@ -322,13 +322,14 @@ export class WaitingRoom {
       if (player.isCPU) {
         meta.append(createChip("CPU"));
         if (this.isHost) {
+          const cpuUserId = player.userId;
           const removeBtn = createElement("button", "waiting-room-remove-cpu", this.cpuRemovePending ? "⏳" : "✕");
           removeBtn.type = "button";
           removeBtn.title = "Remove CPU player";
           if (this.cpuRemovePending) {
             (removeBtn as HTMLButtonElement).disabled = true;
           } else {
-            removeBtn.addEventListener("click", () => this.requestRemoveCpu());
+            removeBtn.addEventListener("click", () => this.requestRemoveCpu(cpuUserId));
           }
           meta.append(removeBtn);
         }
@@ -344,14 +345,12 @@ export class WaitingRoom {
       this.playerListEl.append(item);
     }
 
-    // Add CPU Player slot (host only, CPU-supporting games, room not full, no CPU yet)
-    const hasCpu = this.players.some((p) => p.isCPU);
+    // Add CPU Player slot (host only, CPU-supporting games, room not full)
     const maxPlayers = this.gameInfo?.maxPlayers ?? 0;
     if (
       this.isHost &&
       this.supportsCpuOpponent() &&
-      this.players.length < maxPlayers &&
-      !hasCpu
+      this.players.length < maxPlayers
     ) {
       const slot = createElement("li", "waiting-room-add-cpu");
       const addBtn = createElement("button", "waiting-room-add-cpu-btn") as HTMLButtonElement;
@@ -428,13 +427,13 @@ export class WaitingRoom {
     }
   }
 
-  private requestRemoveCpu(): void {
+  private requestRemoveCpu(cpuSessionId: string): void {
     if (!this.room || !this.gameId || this.cpuRemovePending) {
       return;
     }
 
     this.cpuRemovePending = true;
-    this.room.send(REMOVE_CPU_PLAYER, { gameId: this.gameId });
+    this.room.send(REMOVE_CPU_PLAYER, { gameId: this.gameId, cpuSessionId });
     this.renderPlayerList();
 
     this.cpuRemoveTimeoutId = window.setTimeout(() => {
@@ -509,10 +508,9 @@ export class WaitingRoom {
   }
 
   private updateInviteSectionVisibility(): void {
-    const hasCpu = this.players.some((p) => p.isCPU);
     const isFull =
       this.gameInfo != null && this.players.length >= this.gameInfo.maxPlayers;
-    this.inviteSection.style.display = hasCpu || isFull ? "none" : "";
+    this.inviteSection.style.display = isFull ? "none" : "";
   }
 
   private updatePlayerCount(): void {

--- a/server/src/__tests__/BaseGameRoom.test.ts
+++ b/server/src/__tests__/BaseGameRoom.test.ts
@@ -220,7 +220,7 @@ describeRoom("BaseGameRoom", () => {
     });
 
     mockGameRegistry.get.mockReturnValue(plugin);
-    room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true });
+    room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true, cpuSessionIds: ["cpu-opponent-1"] });
 
     const humanPlayer = createClient("player-1");
     room.clients.push(humanPlayer);
@@ -230,11 +230,11 @@ describeRoom("BaseGameRoom", () => {
     expect(plugin.lifecycle.onPlayerJoin).toHaveBeenNthCalledWith(
       2,
       room.state,
-      expect.objectContaining({ sessionId: "cpu-opponent" }),
+      expect.objectContaining({ sessionId: "cpu-opponent-1" }),
       1,
     );
-    expect(room.state.players.get("cpu-opponent")).toMatchObject({
-      displayName: "CPU Opponent",
+    expect(room.state.players.get("cpu-opponent-1")).toMatchObject({
+      displayName: "CPU Opponent 1",
       playerIndex: 1,
       isConnected: true,
     });

--- a/server/src/__tests__/chess-clock.test.ts
+++ b/server/src/__tests__/chess-clock.test.ts
@@ -553,7 +553,7 @@ describe("Chess Clock Feature", () => {
       });
 
       mockGameRegistry.get.mockReturnValue(plugin);
-      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true });
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true, cpuSessionIds: ["cpu-opponent-1"] });
 
       const human = createClient("player-1");
       room.clients.push(human);
@@ -574,7 +574,7 @@ describe("Chess Clock Feature", () => {
       });
 
       mockGameRegistry.get.mockReturnValue(plugin);
-      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true });
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true, cpuSessionIds: ["cpu-opponent-1"] });
 
       // setSimulationInterval should NOT have been called for chess clocks.
       // It may still be called for onTick, so check that no chess-clock interval was registered.
@@ -724,7 +724,7 @@ describe("Chess Clock Feature", () => {
       });
 
       mockGameRegistry.get.mockReturnValue(plugin);
-      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true, timeControl: "blitz" });
+      room.onCreate({ gameType: "checkers", expectedPlayers: 2, cpuOpponent: true, cpuSessionIds: ["cpu-opponent-1"], timeControl: "blitz" });
 
       const human = createClient("player-1");
       room.clients.push(human);

--- a/server/src/__tests__/lobby-pregame.test.ts
+++ b/server/src/__tests__/lobby-pregame.test.ts
@@ -29,6 +29,8 @@ const { mockCreateRoom, mockGameRegistry, mockedCloseCode, sharedExports } = vi.
     ONLINE_PLAYERS: "online_players",
     LOBBY_LOG_EVENT: "lobby_log_event",
     AVAILABLE_GAME_TYPES: "available_game_types",
+    CPU_SESSION_ID_PREFIX: "cpu-opponent-",
+    isCpuSessionId: (id: string) => id.startsWith("cpu-opponent-"),
     DEFAULT_MAP_SIZE: 128,
     LOBBY_DEFAULTS: {
       MIN_PLAYERS: 1,
@@ -281,9 +283,9 @@ describeLobby("LobbyRoom pregame flow", () => {
       playerCount: 2,
       cpuOpponent: true,
     });
-    expect(getWaitingPlayers(room, gameId).get("cpu-opponent")).toMatchObject({
-      userId: "cpu-opponent",
-      displayName: "CPU Opponent",
+    expect(getWaitingPlayers(room, gameId).get("cpu-opponent-1")).toMatchObject({
+      userId: "cpu-opponent-1",
+      displayName: "CPU Opponent 1",
       isReady: true,
       isCPU: true,
     });
@@ -366,6 +368,7 @@ describeLobby("LobbyRoom pregame flow", () => {
       maxPlayers: 4,
       expectedPlayers: 2,
       cpuOpponent: false,
+      cpuSessionIds: [],
     });
     expect(getGame(room, gameId)?.status).toBe("in_progress");
     expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
@@ -384,6 +387,7 @@ describeLobby("LobbyRoom pregame flow", () => {
       maxPlayers: 2,
       expectedPlayers: 2,
       cpuOpponent: true,
+      cpuSessionIds: ["cpu-opponent-1"],
     });
     expect(getGame(room, gameId)?.status).toBe("in_progress");
     expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
@@ -402,6 +406,7 @@ describeLobby("LobbyRoom pregame flow", () => {
       maxPlayers: 4,
       expectedPlayers: 1,
       cpuOpponent: false,
+      cpuSessionIds: [],
     });
     expect(getGame(room, gameId)).toMatchObject({ headToHeadMode: true, status: "in_progress", playerCount: 1 });
     expect(findPayload(host, GAME_STARTED)).toEqual({
@@ -792,6 +797,7 @@ describeLobby("LobbyRoom pregame flow", () => {
       maxPlayers: 4,
       expectedPlayers: 1,
       cpuOpponent: false,
+      cpuSessionIds: [],
     });
     expect(findPayload(host, GAME_STARTED)).toEqual({ gameId, roomId: "game-room-123", gameType: "checkers" });
   });

--- a/server/src/__tests__/lobby-pregame.test.ts
+++ b/server/src/__tests__/lobby-pregame.test.ts
@@ -31,6 +31,11 @@ const { mockCreateRoom, mockGameRegistry, mockedCloseCode, sharedExports } = vi.
     AVAILABLE_GAME_TYPES: "available_game_types",
     CPU_SESSION_ID_PREFIX: "cpu-opponent-",
     isCpuSessionId: (id: string) => id.startsWith("cpu-opponent-"),
+    extractCpuNumber: (cpuSessionId: string) => {
+      const suffix = cpuSessionId.slice("cpu-opponent-".length);
+      const num = Number.parseInt(suffix, 10);
+      return Number.isFinite(num) && num > 0 ? num : 1;
+    },
     DEFAULT_MAP_SIZE: 128,
     LOBBY_DEFAULTS: {
       MIN_PLAYERS: 1,
@@ -1011,6 +1016,121 @@ describeLobby("LobbyRoom pregame flow", () => {
       host.send.mockClear();
       await room.handleCreateGame(host, { name: "Another Game" });
       expectLobbyError(host, /leave your current game/i);
+    });
+  });
+
+  describe("multi-CPU players", () => {
+    it("allows adding 2+ CPU players to a game", async () => {
+      mockGameRegistry.has.mockReturnValue(true);
+      mockGameRegistry.get.mockReturnValue(createPlugin(2, 4));
+
+      const gameId = await createGame(room, host, { gameType: "checkers", maxPlayers: 4 });
+
+      room.handleAddCpuPlayer(host, { gameId });
+      room.handleAddCpuPlayer(host, { gameId });
+
+      const players = getWaitingPlayers(room, gameId);
+      expect(players.has("cpu-opponent-1")).toBe(true);
+      expect(players.has("cpu-opponent-2")).toBe(true);
+      expect(players.get("cpu-opponent-1")).toMatchObject({
+        displayName: "CPU Opponent 1",
+        isReady: true,
+        isCPU: true,
+      });
+      expect(players.get("cpu-opponent-2")).toMatchObject({
+        displayName: "CPU Opponent 2",
+        isReady: true,
+        isCPU: true,
+      });
+      expect(getGame(room, gameId)?.playerCount).toBe(3);
+    });
+
+    it("removes a specific CPU player, not just the last one", async () => {
+      mockGameRegistry.has.mockReturnValue(true);
+      mockGameRegistry.get.mockReturnValue(createPlugin(2, 4));
+
+      const gameId = await createGame(room, host, { gameType: "checkers", maxPlayers: 4 });
+
+      room.handleAddCpuPlayer(host, { gameId });
+      room.handleAddCpuPlayer(host, { gameId });
+
+      const players = getWaitingPlayers(room, gameId);
+      expect(players.has("cpu-opponent-1")).toBe(true);
+      expect(players.has("cpu-opponent-2")).toBe(true);
+
+      room.handleRemoveCpuPlayer(host, { gameId, cpuSessionId: "cpu-opponent-1" });
+
+      expect(players.has("cpu-opponent-1")).toBe(false);
+      expect(players.has("cpu-opponent-2")).toBe(true);
+      expect(getGame(room, gameId)?.playerCount).toBe(2);
+      expect(getGame(room, gameId)?.cpuOpponent).toBe(true);
+    });
+
+    it("starts a game with a mix of CPUs and humans", async () => {
+      mockGameRegistry.has.mockReturnValue(true);
+      mockGameRegistry.get.mockReturnValue(createPlugin(2, 4));
+
+      const gameId = await createGame(room, host, { gameType: "checkers", maxPlayers: 4 });
+      await room.handleJoinGame(guest, { gameId });
+
+      room.handleAddCpuPlayer(host, { gameId });
+
+      const players = getWaitingPlayers(room, gameId);
+      expect(players.size).toBe(3);
+
+      room.handleSetReady(host, { ready: true });
+      room.handleSetReady(guest, { ready: true });
+
+      host.send.mockClear();
+      guest.send.mockClear();
+      await room.handleStartGame(host);
+
+      expect(mockCreateRoom).toHaveBeenCalledWith("game", expect.objectContaining({
+        gameId,
+        gameType: "checkers",
+        maxPlayers: 4,
+        expectedPlayers: 3,
+        cpuOpponent: true,
+        cpuSessionIds: ["cpu-opponent-1"],
+      }));
+      expect(getGame(room, gameId)?.status).toBe("in_progress");
+      expect(findPayload(host, GAME_STARTED)).toEqual(expect.objectContaining({ gameId }));
+      expect(findPayload(guest, GAME_STARTED)).toEqual(expect.objectContaining({ gameId }));
+    });
+
+    it("sets cpuOpponent to false when all CPUs are removed", async () => {
+      mockGameRegistry.has.mockReturnValue(true);
+      mockGameRegistry.get.mockReturnValue(createPlugin(2, 4));
+
+      const gameId = await createGame(room, host, { gameType: "checkers", maxPlayers: 4 });
+
+      room.handleAddCpuPlayer(host, { gameId });
+      expect(getGame(room, gameId)?.cpuOpponent).toBe(true);
+
+      room.handleRemoveCpuPlayer(host, { gameId, cpuSessionId: "cpu-opponent-1" });
+      expect(getGame(room, gameId)?.cpuOpponent).toBe(false);
+      expect(getGame(room, gameId)?.playerCount).toBe(1);
+    });
+
+    it("starts a game with multiple CPU session IDs passed to createRoom", async () => {
+      mockGameRegistry.has.mockReturnValue(true);
+      mockGameRegistry.get.mockReturnValue(createPlugin(2, 4));
+
+      const gameId = await createGame(room, host, { gameType: "checkers", maxPlayers: 4 });
+
+      room.handleAddCpuPlayer(host, { gameId });
+      room.handleAddCpuPlayer(host, { gameId });
+      room.handleAddCpuPlayer(host, { gameId });
+
+      room.handleSetReady(host, { ready: true });
+
+      host.send.mockClear();
+      await room.handleStartGame(host);
+
+      expect(mockCreateRoom).toHaveBeenCalledWith("game", expect.objectContaining({
+        cpuOpponent: true,
+        cpuSessionIds: ["cpu-opponent-1", "cpu-opponent-2", "cpu-opponent-3"],
+      }));
     });
   });
 });

--- a/server/src/__tests__/move-history.test.ts
+++ b/server/src/__tests__/move-history.test.ts
@@ -506,17 +506,17 @@ describeRoom("Move History — P6.1 Core Infrastructure", () => {
       room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
 
       const humanPlayer = createClient("player-1");
-      const cpuClient = createClient("cpu-opponent");
+      const cpuClient = createClient("cpu-opponent-1");
       room.clients.push(humanPlayer, cpuClient);
       room.onJoin(humanPlayer, { displayName: "Alice" });
-      room.onJoin(cpuClient, { displayName: "CPU Opponent" });
+      room.onJoin(cpuClient, { displayName: "CPU Opponent 1" });
 
       await room.messageHandlers.get("move")?.(humanPlayer, { from: 17, to: 24 });
       await room.messageHandlers.get("move")?.(cpuClient, { from: 40, to: 33 });
 
       expect(room.moveHistory).toHaveLength(2);
-      expect(room.moveHistory[1].playerId).toBe("cpu-opponent");
-      expect(room.moveHistory[1].playerName).toBe("CPU Opponent");
+      expect(room.moveHistory[1].playerId).toBe("cpu-opponent-1");
+      expect(room.moveHistory[1].playerName).toBe("CPU Opponent 1");
     });
 
     it("distinguishes CPU moves from human player moves", async () => {
@@ -526,10 +526,10 @@ describeRoom("Move History — P6.1 Core Infrastructure", () => {
       room.onCreate({ gameType: "checkers", expectedPlayers: 2 });
 
       const humanPlayer = createClient("player-1");
-      const cpuClient = createClient("cpu-opponent");
+      const cpuClient = createClient("cpu-opponent-1");
       room.clients.push(humanPlayer, cpuClient);
       room.onJoin(humanPlayer, { displayName: "Alice" });
-      room.onJoin(cpuClient, { displayName: "CPU Opponent" });
+      room.onJoin(cpuClient, { displayName: "CPU Opponent 1" });
 
       await room.messageHandlers.get("move")?.(humanPlayer, { from: 17, to: 24 });
       await room.messageHandlers.get("move")?.(cpuClient, { from: 40, to: 33 });
@@ -538,7 +538,7 @@ describeRoom("Move History — P6.1 Core Infrastructure", () => {
       const cpuMove = room.moveHistory[1] as MoveEntry;
 
       expect(humanMove.playerId).not.toBe(cpuMove.playerId);
-      expect(cpuMove.playerId).toBe("cpu-opponent");
+      expect(cpuMove.playerId).toBe("cpu-opponent-1");
     });
   });
 

--- a/server/src/game/BaseGameRoom.ts
+++ b/server/src/game/BaseGameRoom.ts
@@ -2,9 +2,9 @@ import type { Delayed } from "@colyseus/timer";
 import { Client, CloseCode, Room } from "colyseus";
 import {
   BaseGameState,
-  CPU_SESSION_ID_PREFIX,
   PlayerInfo,
   TIME_CONTROL_MS,
+  extractCpuNumber,
   isCpuSessionId,
   type ActionHandler,
   type BackgammonState,
@@ -595,7 +595,7 @@ export class BaseGameRoom extends Room {
         continue;
       }
 
-      const cpuNumber = this.extractCpuNumber(cpuId);
+      const cpuNumber = extractCpuNumber(cpuId);
       const playerIndex = this.getParticipatingPlayers().length;
       const player = new PlayerInfo();
       player.sessionId = cpuId;
@@ -625,12 +625,6 @@ export class BaseGameRoom extends Room {
         }
       }
     }
-  }
-
-  private extractCpuNumber(cpuSessionId: string): number {
-    const suffix = cpuSessionId.slice(CPU_SESSION_ID_PREFIX.length);
-    const num = Number.parseInt(suffix, 10);
-    return Number.isFinite(num) && num > 0 ? num : 1;
   }
 
   private ensureHeadToHeadParticipant(client: Client) {

--- a/server/src/game/BaseGameRoom.ts
+++ b/server/src/game/BaseGameRoom.ts
@@ -2,8 +2,10 @@ import type { Delayed } from "@colyseus/timer";
 import { Client, CloseCode, Room } from "colyseus";
 import {
   BaseGameState,
+  CPU_SESSION_ID_PREFIX,
   PlayerInfo,
   TIME_CONTROL_MS,
+  isCpuSessionId,
   type ActionHandler,
   type BackgammonState,
   type CheckersState,
@@ -26,6 +28,7 @@ import { TurnManager } from "./TurnManager.js";
 
 interface BaseGameRoomOptions extends GameOptions {
   cpuOpponent?: boolean;
+  cpuSessionIds?: string[];
   gameId?: string;
   gameType?: string;
   headToHeadMode?: boolean;
@@ -36,7 +39,6 @@ interface BaseGameRoomOptions extends GameOptions {
 }
 
 const CPU_OPPONENT_DISPLAY_NAME = "CPU Opponent";
-const CPU_OPPONENT_SESSION_ID = "cpu-opponent";
 const CPU_TURN_DELAY_MS = 200;
 const DEFAULT_ACTION_ERROR = "Action failed.";
 const DEFAULT_RECONNECTION_TIMEOUT = 30;
@@ -57,6 +59,7 @@ export class BaseGameRoom extends Room {
   private lobbyGameId?: string;
   private gameStartTime?: number;
   private cpuOpponentEnabled = false;
+  private cpuSessionIds: string[] = [];
   private pendingCpuTurn?: Delayed;
   private headToHeadMode = false;
   private moveHistory: MoveEntry[] = [];
@@ -71,6 +74,9 @@ export class BaseGameRoom extends Room {
     this.plugin = gameRegistry.get(gameType) as unknown as GamePlugin<BaseGameState>;
     this.cpuOpponentEnabled = options.cpuOpponent === true
       && (gameType === "checkers" || gameType === "backgammon" || gameType === "dominos");
+    this.cpuSessionIds = Array.isArray(options.cpuSessionIds)
+      ? options.cpuSessionIds.filter(isCpuSessionId)
+      : [];
     this.headToHeadMode = options.headToHeadMode === true && gameType === "checkers";
 
     const [minPlayers, maxPlayers] = this.plugin.metadata.playerCount;
@@ -196,7 +202,7 @@ export class BaseGameRoom extends Room {
     }
 
     if (!isSpectator) {
-      this.ensureCpuParticipant(client.sessionId);
+      this.ensureCpuParticipants(client.sessionId);
       this.ensureHeadToHeadParticipant(client);
       if (this.shouldStartGame()) {
         this.startGame();
@@ -579,39 +585,52 @@ export class BaseGameRoom extends Room {
     }
   }
 
-  private ensureCpuParticipant(controllerSessionId: string) {
-    if (!this.cpuOpponentEnabled || this.state.players.has(CPU_OPPONENT_SESSION_ID)) {
+  private ensureCpuParticipants(controllerSessionId: string) {
+    if (!this.cpuOpponentEnabled || this.cpuSessionIds.length === 0) {
       return;
     }
 
-    const playerIndex = this.getParticipatingPlayers().length;
-    const player = new PlayerInfo();
-    player.sessionId = CPU_OPPONENT_SESSION_ID;
-    player.displayName = CPU_OPPONENT_DISPLAY_NAME;
-    player.playerIndex = playerIndex;
-    player.isSpectator = false;
-    player.isConnected = true;
-    player.controllerSessionId = controllerSessionId;
+    for (const cpuId of this.cpuSessionIds) {
+      if (this.state.players.has(cpuId)) {
+        continue;
+      }
 
-    this.state.players.set(CPU_OPPONENT_SESSION_ID, player);
-    this.plugin.lifecycle.onPlayerJoin?.(
-      this.state,
-      this.createSyntheticClient(CPU_OPPONENT_SESSION_ID),
-      playerIndex,
-    );
+      const cpuNumber = this.extractCpuNumber(cpuId);
+      const playerIndex = this.getParticipatingPlayers().length;
+      const player = new PlayerInfo();
+      player.sessionId = cpuId;
+      player.displayName = `${CPU_OPPONENT_DISPLAY_NAME} ${cpuNumber}`;
+      player.playerIndex = playerIndex;
+      player.isSpectator = false;
+      player.isConnected = true;
+      player.controllerSessionId = controllerSessionId;
 
-    if (this.gameId) {
-      try {
-        const pool = getPool();
-        void gameRepository.addParticipant(pool, {
-          gameId: this.gameId,
-          userId: CPU_OPPONENT_SESSION_ID,
-          role: "player",
-        });
-      } catch (error) {
-        console.error("[BaseGameRoom] Failed to add CPU participant to DB:", error);
+      this.state.players.set(cpuId, player);
+      this.plugin.lifecycle.onPlayerJoin?.(
+        this.state,
+        this.createSyntheticClient(cpuId),
+        playerIndex,
+      );
+
+      if (this.gameId) {
+        try {
+          const pool = getPool();
+          void gameRepository.addParticipant(pool, {
+            gameId: this.gameId,
+            userId: cpuId,
+            role: "player",
+          });
+        } catch (error) {
+          console.error("[BaseGameRoom] Failed to add CPU participant to DB:", error);
+        }
       }
     }
+  }
+
+  private extractCpuNumber(cpuSessionId: string): number {
+    const suffix = cpuSessionId.slice(CPU_SESSION_ID_PREFIX.length);
+    const num = Number.parseInt(suffix, 10);
+    return Number.isFinite(num) && num > 0 ? num : 1;
   }
 
   private ensureHeadToHeadParticipant(client: Client) {
@@ -674,7 +693,7 @@ export class BaseGameRoom extends Room {
 
   private isCpuTurn(sessionId: string) {
     return this.cpuOpponentEnabled
-      && sessionId === CPU_OPPONENT_SESSION_ID;
+      && isCpuSessionId(sessionId);
   }
 
   private async executeCpuTurn() {
@@ -696,9 +715,10 @@ export class BaseGameRoom extends Room {
   }
 
   private async executeCheckersCpuTurn() {
+    const cpuSessionId = this.state.currentTurn;
     const move = selectCpuMove(this.state as CheckersState);
     if (!move) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 
@@ -708,7 +728,7 @@ export class BaseGameRoom extends Room {
     }
 
     const didProcessAction = await this.processAction(
-      this.createSyntheticClient(CPU_OPPONENT_SESSION_ID),
+      this.createSyntheticClient(cpuSessionId),
       "move",
       move,
       moveHandler as ActionHandler<BaseGameState>,
@@ -716,7 +736,7 @@ export class BaseGameRoom extends Room {
     );
 
     if (!didProcessAction) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 
@@ -724,9 +744,10 @@ export class BaseGameRoom extends Room {
   }
 
   private async executeBackgammonCpuTurn() {
+    const cpuSessionId = this.state.currentTurn;
     const action = selectCpuAction(this.state as BackgammonState);
     if (!action) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 
@@ -737,7 +758,7 @@ export class BaseGameRoom extends Room {
 
     const payload = action.actionType === "move" ? action.payload : undefined;
     const didProcessAction = await this.processAction(
-      this.createSyntheticClient(CPU_OPPONENT_SESSION_ID),
+      this.createSyntheticClient(cpuSessionId),
       action.actionType,
       payload,
       handler as ActionHandler<BaseGameState>,
@@ -745,7 +766,7 @@ export class BaseGameRoom extends Room {
     );
 
     if (!didProcessAction) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 
@@ -753,9 +774,10 @@ export class BaseGameRoom extends Room {
   }
 
   private async executeDominosCpuTurn() {
+    const cpuSessionId = this.state.currentTurn;
     const action = selectDominosCpuAction(this.state as DominosState);
     if (!action) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 
@@ -766,7 +788,7 @@ export class BaseGameRoom extends Room {
 
     const payload = action.actionType === "play" ? action.payload : undefined;
     const didProcessAction = await this.processAction(
-      this.createSyntheticClient(CPU_OPPONENT_SESSION_ID),
+      this.createSyntheticClient(cpuSessionId),
       action.actionType,
       payload,
       handler as ActionHandler<BaseGameState>,
@@ -774,7 +796,7 @@ export class BaseGameRoom extends Room {
     );
 
     if (!didProcessAction) {
-      await this.handleTurnTimeout(CPU_OPPONENT_SESSION_ID);
+      await this.handleTurnTimeout(cpuSessionId);
       return;
     }
 

--- a/server/src/rooms/LobbyRoom.ts
+++ b/server/src/rooms/LobbyRoom.ts
@@ -2,6 +2,7 @@ import { Client, CloseCode, Room, matchMaker } from "colyseus";
 import {
   ADD_CPU_PLAYER,
   AVAILABLE_GAME_TYPES,
+  CPU_SESSION_ID_PREFIX,
   CREATE_GAME,
   GAME_JOINED,
   GAME_LIST,
@@ -17,6 +18,7 @@ import {
   REMOVE_CPU_PLAYER,
   SET_READY,
   START_GAME,
+  isCpuSessionId,
   type AddCpuPlayerPayload,
   type CreateGamePayload,
   type GameJoinedPayload,
@@ -42,7 +44,6 @@ const LOBBY_RECONNECTION_TIMEOUT_SECONDS = 30;
 const MAX_GAME_NAME_LENGTH = 32;
 const MAX_DISPLAY_NAME_LENGTH = 24;
 const MAX_PLAYER_ID_LENGTH = 64;
-const CPU_OPPONENT_SESSION_ID = "cpu-opponent";
 const CPU_OPPONENT_DISPLAY_NAME = "CPU Opponent";
 
 interface LobbySession {
@@ -275,7 +276,8 @@ export class LobbyRoom extends Room {
     ]);
 
     if (cpuOpponent) {
-      waitingPlayers.set(CPU_OPPONENT_SESSION_ID, this.createCpuPreGamePlayerInfo());
+      const cpuId = this.nextCpuSessionId(waitingPlayers);
+      waitingPlayers.set(cpuId, this.createCpuPreGamePlayerInfo(cpuId));
     }
 
     this.games.set(gameId, game);
@@ -476,6 +478,7 @@ export class LobbyRoom extends Room {
     }
 
     try {
+      const cpuSessionIds = [...players.keys()].filter(isCpuSessionId);
       const room = await matchMaker.createRoom("game", {
         gameId: game.id,
         gameType: game.gameType,
@@ -485,6 +488,7 @@ export class LobbyRoom extends Room {
         maxPlayers: game.maxPlayers,
         expectedPlayers: players.size,
         cpuOpponent: game.cpuOpponent === true,
+        cpuSessionIds,
       });
 
       game.status = "in_progress";
@@ -578,17 +582,13 @@ export class LobbyRoom extends Room {
       return;
     }
 
-    if (players.has(CPU_OPPONENT_SESSION_ID)) {
-      this.sendError(client, "A CPU player is already in this game.");
-      return;
-    }
-
     if (players.size >= game.maxPlayers) {
       this.sendError(client, "Game is full.");
       return;
     }
 
-    players.set(CPU_OPPONENT_SESSION_ID, this.createCpuPreGamePlayerInfo());
+    const cpuId = this.nextCpuSessionId(players);
+    players.set(cpuId, this.createCpuPreGamePlayerInfo(cpuId));
     game.cpuOpponent = true;
     game.playerCount = players.size;
 
@@ -627,13 +627,17 @@ export class LobbyRoom extends Room {
       return;
     }
 
-    if (!players.has(CPU_OPPONENT_SESSION_ID)) {
+    const cpuIdToRemove = payload.cpuSessionId
+      ? (isCpuSessionId(payload.cpuSessionId) ? payload.cpuSessionId : undefined)
+      : this.findLastCpuSessionId(players);
+
+    if (!cpuIdToRemove || !players.has(cpuIdToRemove)) {
       this.sendError(client, "No CPU player in this game.");
       return;
     }
 
-    players.delete(CPU_OPPONENT_SESSION_ID);
-    game.cpuOpponent = false;
+    players.delete(cpuIdToRemove);
+    game.cpuOpponent = [...players.values()].some((p) => p.isCPU === true);
     game.playerCount = players.size;
 
     this.broadcast(GAME_UPDATED, { game: this.toGameSessionInfo(game) });
@@ -809,13 +813,39 @@ export class LobbyRoom extends Room {
     };
   }
 
-  private createCpuPreGamePlayerInfo(): PreGamePlayerInfo {
+  private createCpuPreGamePlayerInfo(cpuSessionId: string): PreGamePlayerInfo {
+    const cpuNumber = this.extractCpuNumber(cpuSessionId);
     return {
-      userId: CPU_OPPONENT_SESSION_ID,
-      displayName: CPU_OPPONENT_DISPLAY_NAME,
+      userId: cpuSessionId,
+      displayName: `${CPU_OPPONENT_DISPLAY_NAME} ${cpuNumber}`,
       isReady: true,
       isCPU: true,
     };
+  }
+
+  private nextCpuSessionId(players: Map<string, PreGamePlayerInfo>): string {
+    let maxNum = 0;
+    for (const key of players.keys()) {
+      if (isCpuSessionId(key)) {
+        const num = this.extractCpuNumber(key);
+        if (num > maxNum) maxNum = num;
+      }
+    }
+    return `${CPU_SESSION_ID_PREFIX}${maxNum + 1}`;
+  }
+
+  private extractCpuNumber(cpuSessionId: string): number {
+    const suffix = cpuSessionId.slice(CPU_SESSION_ID_PREFIX.length);
+    const num = Number.parseInt(suffix, 10);
+    return Number.isFinite(num) && num > 0 ? num : 1;
+  }
+
+  private findLastCpuSessionId(players: Map<string, PreGamePlayerInfo>): string | undefined {
+    let lastCpu: string | undefined;
+    for (const key of players.keys()) {
+      if (isCpuSessionId(key)) lastCpu = key;
+    }
+    return lastCpu;
   }
 
   private sendAvailableGameTypes(client: Client) {

--- a/server/src/rooms/LobbyRoom.ts
+++ b/server/src/rooms/LobbyRoom.ts
@@ -18,6 +18,7 @@ import {
   REMOVE_CPU_PLAYER,
   SET_READY,
   START_GAME,
+  extractCpuNumber,
   isCpuSessionId,
   type AddCpuPlayerPayload,
   type CreateGamePayload,
@@ -814,7 +815,7 @@ export class LobbyRoom extends Room {
   }
 
   private createCpuPreGamePlayerInfo(cpuSessionId: string): PreGamePlayerInfo {
-    const cpuNumber = this.extractCpuNumber(cpuSessionId);
+    const cpuNumber = extractCpuNumber(cpuSessionId);
     return {
       userId: cpuSessionId,
       displayName: `${CPU_OPPONENT_DISPLAY_NAME} ${cpuNumber}`,
@@ -827,17 +828,11 @@ export class LobbyRoom extends Room {
     let maxNum = 0;
     for (const key of players.keys()) {
       if (isCpuSessionId(key)) {
-        const num = this.extractCpuNumber(key);
+        const num = extractCpuNumber(key);
         if (num > maxNum) maxNum = num;
       }
     }
     return `${CPU_SESSION_ID_PREFIX}${maxNum + 1}`;
-  }
-
-  private extractCpuNumber(cpuSessionId: string): number {
-    const suffix = cpuSessionId.slice(CPU_SESSION_ID_PREFIX.length);
-    const num = Number.parseInt(suffix, 10);
-    return Number.isFinite(num) && num > 0 ? num : 1;
   }
 
   private findLastCpuSessionId(players: Map<string, PreGamePlayerInfo>): string | undefined {

--- a/shared/src/lobbyTypes.ts
+++ b/shared/src/lobbyTypes.ts
@@ -92,6 +92,12 @@ export function isCpuSessionId(sessionId: string): boolean {
   return sessionId.startsWith(CPU_SESSION_ID_PREFIX);
 }
 
+export function extractCpuNumber(cpuSessionId: string): number {
+  const suffix = cpuSessionId.slice(CPU_SESSION_ID_PREFIX.length);
+  const num = Number.parseInt(suffix, 10);
+  return Number.isFinite(num) && num > 0 ? num : 1;
+}
+
 export interface PreGamePlayerInfo {
   userId: string;
   displayName: string;

--- a/shared/src/lobbyTypes.ts
+++ b/shared/src/lobbyTypes.ts
@@ -83,6 +83,13 @@ export interface AddCpuPlayerPayload {
 
 export interface RemoveCpuPlayerPayload {
   gameId: string;
+  cpuSessionId?: string;
+}
+
+export const CPU_SESSION_ID_PREFIX = "cpu-opponent-";
+
+export function isCpuSessionId(sessionId: string): boolean {
+  return sessionId.startsWith(CPU_SESSION_ID_PREFIX);
 }
 
 export interface PreGamePlayerInfo {


### PR DESCRIPTION
## Summary
Implements support for multiple CPU players in games that allow more than 2 players (Dominos 2-4, Risk 2-6).

Closes #176

## Changes

### Shared types
- Added `CPU_SESSION_ID_PREFIX` (`"cpu-opponent-"`) and `isCpuSessionId()` helper to `lobbyTypes.ts`
- Extended `RemoveCpuPlayerPayload` with optional `cpuSessionId` for targeted removal

### Server — LobbyRoom
- CPU session IDs are now unique and incrementing: `cpu-opponent-1`, `cpu-opponent-2`, etc.
- Removed single-CPU restriction — host can add CPUs up to `maxPlayers`
- `REMOVE_CPU_PLAYER` accepts optional `cpuSessionId` to remove a specific CPU
- Passes `cpuSessionIds[]` array to game room on start

### Server — BaseGameRoom
- `ensureCpuParticipants()` creates all CPU players from the session ID list
- `isCpuTurn()` uses prefix matching (`startsWith`) instead of exact ID
- CPU turn executors use `this.state.currentTurn` dynamically (no hardcoded ID)

### Client — WaitingRoom & SetupScreen
- Remove buttons pass specific CPU session ID for targeted removal
- Invite section stays visible with CPUs present (hidden only when game is full)

### Client — CheckersRenderer
- Uses `CPU_SESSION_ID_PREFIX` for head-to-head detection instead of hardcoded string

### Tests
- Updated all CPU-related tests for new ID format (`cpu-opponent-1`)
- Added `cpuSessionIds` to test room creation options

## Validation
- `npm run build` ✓
- `npm run lint` ✓
- `npm run test` ✓ (803 passed, 12 todo)